### PR TITLE
Remove code wrapping within URL

### DIFF
--- a/src/python/nimbusml/internal/core/cluster/kmeansplusplus.py
+++ b/src/python/nimbusml/internal/core/cluster/kmeansplusplus.py
@@ -34,9 +34,8 @@ class KMeansPlusPlus(BasePipelineItem, DefaultSignatureWithRoles):
 
         **Reference**
 
-            `https://www.microsoft.com/en-us/research/wp-
-            content/uploads/2016/02/ding15.pdf <https://www.microsoft.com/en-
-            us/research/wp-content/uploads/2016/02/ding15.pdf>`_
+            `https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/ding15.pdf 
+            <https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/ding15.pdf>`_
 
 
     :param normalize: Specifies the type of automatic normalization used:


### PR DESCRIPTION
The wrapping of the URL seems to be adding an extra space in the rendered doc's version of the URL: 

> ![extraspace](https://user-images.githubusercontent.com/4080826/47896131-2c1e2a80-de29-11e8-8783-f196400f4797.png)

Rendered docs: https://docs.microsoft.com/en-us/python/api/nimbusml/nimbusml.cluster.kmeansplusplus?view=nimbusml-py-latest#remarks