### PR TITLE
Speed up builds by reducing redundancy in the build matrix

### DIFF
--- a/build/vsts-ci-nightly.yml
+++ b/build/vsts-ci-nightly.yml
@@ -23,6 +23,10 @@ phases:
     buildMatrix:
       Py36:
         _configuration: RlsMacPy3.6
+      Py35:
+        _configuration: RlsMacPy3.5
+      Py27:
+        _configuration: RlsMacPy2.7
     buildQueue:
       name: Hosted macOS
 
@@ -34,8 +38,27 @@ phases:
     buildScript: ./build.sh
     testDistro: ubuntu16
     buildMatrix:
+      Py36:
+        _configuration: RlsLinPy3.6
       Py35:
         _configuration: RlsLinPy3.5
+      Py27:
+        _configuration: RlsLinPy2.7
+    buildQueue:
+      name: Hosted Ubuntu 1604
+  # Run tests on Ubuntu14
+- template: /build/ci/phase-template.yml
+  parameters:
+    name: Linux_Ubuntu14
+    buildScript: ./build.sh
+    testDistro: ubuntu14
+    buildMatrix:
+      Py36:
+        _configuration: RlsLinPy3.6
+      Py35:
+        _configuration: RlsLinPy3.5
+      Py27:
+        _configuration: RlsLinPy2.7
     buildQueue:
       name: Hosted Ubuntu 1604
   # Run tests on CentOS7
@@ -45,6 +68,10 @@ phases:
     buildScript: ./build.sh
     testDistro: centos7
     buildMatrix:
+      Py36:
+        _configuration: RlsLinPy3.6
+      Py35:
+        _configuration: RlsLinPy3.5
       Py27:
         _configuration: RlsLinPy2.7
     buildQueue:


### PR DESCRIPTION
Reduce number of build legs for PR validations and add nightly build definition with more robust build matrix.
