### PR TITLE
Fixed the issue of Ubuntu14 not skipping Image.py and Image_df.py

### DIFF
--- a/src/python/tests_extended/test_docs_example.py
+++ b/src/python/tests_extended/test_docs_example.py
@@ -71,7 +71,7 @@ class TestDocsExamples(unittest.TestCase):
                     ]:
                     continue
             # skip for ubuntu 14 tests
-            if platform.linux_distribution()[0] == 'Ubuntu' and platform.linux_distribution()[1][:2] == '14':
+            if platform.linux_distribution()[1] == 'jessie/sid':
                 if name in [
                     # libdl needs to be setup
                     'Image.py',


### PR DESCRIPTION
* Inside the docker of ubunu14 during the build, platform.linux_distribtuion() didn't return Ubuntu 14, instead it returns 'debian' and 'jessie/sid'. This was the reason of Ubuntu14 not skipping image.py and image_df.py.
