### PR TITLE
Skip CharTokenizer.py for extended tests

### DIFF
--- a/src/python/tests_extended/test_docs_example.py
+++ b/src/python/tests_extended/test_docs_example.py
@@ -65,6 +65,7 @@ class TestDocsExamples(unittest.TestCase):
                     'SymSgdBinaryClassifier.py',
                     'SymSgdBinaryClassifier_infert_df.py',
                     # MICROSOFTML_RESOURCE_PATH needs to be setup on linux
+                    'CharTokenizer.py',
                     'WordEmbedding.py',
                     'WordEmbedding_df.py',
                     'NaiveBayesClassifier_df.py'


### PR DESCRIPTION
* Skip CharTokenizer.py for extended tests just like WordEmbedding.py due to the FIleSystem Permissions Error. `Fixed #162 `
