### PR TITLE
Use restored dotnet CLI for signing

### DIFF
--- a/build/signed_build_phase.yml
+++ b/build/signed_build_phase.yml
@@ -28,7 +28,7 @@ phases:
     continueOnError: false
     condition: and(succeeded(), in(variables._SignType, 'real', 'test'))
 
-  - script: ./build.cmd --buildDotNetBridgeOnly --configuration $(BuildConfig)
+  - script: ./build.cmd --buildDotNetBridgeOnly --azureBuild --configuration $(BuildConfig)
     displayName: Build DotNetBridgeOnly
   
   - task: MSBuild@1


### PR DESCRIPTION
This adds the dotnet CLI required to build the repo to the path when in building in azure devops. This helps avoiding issues like "The current .NET SDK does not support targeting .NET Standard 2.0.  Either target .NET Standard 1.6 or lower"