### PR TITLE
Add get_feature_contributions method to Pipeline

### DIFF
--- a/src/python/nimbusml.pyproj
+++ b/src/python/nimbusml.pyproj
@@ -177,7 +177,7 @@
     <Compile Include="nimbusml\examples\PipelineWithGridSearchCV2.py" />
     <Compile Include="nimbusml\examples\PipelineWithGridSearchCV1.py" />
     <Compile Include="nimbusml\examples\pipeline.py" />
-    <Compile Include="nu,busml\examples\PipelineWithFeatureCOntributions.py" />
+    <Compile Include="nimbusml\examples\PipelineWithFeatureCOntributions.py" />
     <Compile Include="nimbusml\examples\Poisson.py" />
     <Compile Include="nimbusml\examples\PoissonRegressionRegressor.py" />
     <Compile Include="nimbusml\examples\RangeFilter.py" />

--- a/src/python/nimbusml.pyproj
+++ b/src/python/nimbusml.pyproj
@@ -177,7 +177,7 @@
     <Compile Include="nimbusml\examples\PipelineWithGridSearchCV2.py" />
     <Compile Include="nimbusml\examples\PipelineWithGridSearchCV1.py" />
     <Compile Include="nimbusml\examples\pipeline.py" />
-    <Compile Include="nimbusml\examples\PipelineWithFeatureCOntributions.py" />
+    <Compile Include="nimbusml\examples\PipelineWithFeatureContributions.py" />
     <Compile Include="nimbusml\examples\Poisson.py" />
     <Compile Include="nimbusml\examples\PoissonRegressionRegressor.py" />
     <Compile Include="nimbusml\examples\RangeFilter.py" />

--- a/src/python/nimbusml.pyproj
+++ b/src/python/nimbusml.pyproj
@@ -177,6 +177,7 @@
     <Compile Include="nimbusml\examples\PipelineWithGridSearchCV2.py" />
     <Compile Include="nimbusml\examples\PipelineWithGridSearchCV1.py" />
     <Compile Include="nimbusml\examples\pipeline.py" />
+    <Compile Include="nu,busml\examples\PipelineWithFeatureCOntributions.py" />
     <Compile Include="nimbusml\examples\Poisson.py" />
     <Compile Include="nimbusml\examples\PoissonRegressionRegressor.py" />
     <Compile Include="nimbusml\examples\RangeFilter.py" />

--- a/src/python/nimbusml/base_predictor.py
+++ b/src/python/nimbusml/base_predictor.py
@@ -98,6 +98,10 @@ class BasePredictor(BaseEstimator, BasePipelineItem):
         return data
 
     @trace
+    def get_feature_contributions(self, X, **params):
+        return self._invoke_inference_method('get_feature_contributions', X, **params)
+    
+    @trace
     def predict(self, X, **params):
         """
         Predict target value

--- a/src/python/nimbusml/examples/PipelineWithFeatureContributions.py
+++ b/src/python/nimbusml/examples/PipelineWithFeatureContributions.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Pipeline with feature contributions
+# Pipeline with observation level feature contributions
 
 # Scoring a dataset with a trained model produces a score, or prediction, for
 # each example. To understand and explain these predictions it can be useful to
@@ -7,32 +7,6 @@
 # computes a model-specific list of per-feature contributions to the score for
 # each example. These contributions can be positive (they make the score
 # higher) or negative (they make the score lower).
-#
-# Feature Contribution Calculation is currently supported for the following
-# models:
-#   - Regression:
-#     - OrdinaryLeastSquaresRegressor
-#     - FastLinearRegressor
-#     - OnlineGradientDescentRegressor
-#     - PoissonRegressionRegressor
-#     - GamRegressor
-#     - LightGbmRegressor
-#     - FastTreesRegressor
-#     - FastForestRegressor
-#     - FastTreesTweedieRegressor
-#   - Binary Classification:
-#     - AveragedPerceptronBinaryClassifier
-#     - LinearSvmBinaryClassifier
-#     - LogisticRegressionBinaryClassifier
-#     - FastLinearBinaryClassifier
-#     - SgdBinaryClassifier
-#     - SymSgdBinaryClassifier
-#     - GamBinaryClassifier
-#     - FastForestBinaryClassifier
-#     - FastTreesBinaryClassifier
-#     - LightGbmBinaryClassifier
-#   - Ranking:
-#     - LightGbmRanker
 
 from nimbusml import Pipeline, FileDataStream
 from nimbusml.datasets import get_dataset
@@ -69,14 +43,11 @@ lr_feature_contributions = lr_model.get_feature_contributions(data)
 print("========== Feature Contributions for Linear Model ==========")
 print(lr_feature_contributions.head())
 #   label  ... PredictedLabel     Score ... FeatureContributions.hours-per-week
-# 0        ...              0 -2.010687 ...                            0.833069
-# 1        ...              0 -1.216163 ...                            0.809928
-# 2        ...              0 -1.248412 ...                            0.485957
-# 3        ...              0 -1.132419 ...                            0.583148
-# 4        ...              0 -1.969522 ...                            0.437361
-
-assert 'FeatureContributions.age' in lr_feature_contributions.columns
-
+# 0     0  ...              0 -2.010687 ...                            0.833069
+# 1     0  ...              0 -1.216163 ...                            0.809928
+# 2     1  ...              0 -1.248412 ...                            0.485957
+# 3     1  ...              0 -1.132419 ...                            0.583148
+# 4     0  ...              0 -1.969522 ...                            0.437361
 
 # define the training pipeline with a tree model
 tree_pipeline = Pipeline([FastTreesBinaryClassifier(
@@ -106,3 +77,9 @@ tree_feature_contributions = tree_model.get_feature_contributions(data)
 # of how much each feature impacted the Score.
 print("========== Feature Contributions for Tree Model ==========")
 print(tree_feature_contributions.head())
+#    label  ... PredictedLabel      Score ... FeatureContributions.hours-per-week
+# 0      0  ...              0 -16.717360 ...                           -0.608664
+# 1      0  ...              0  -7.688200 ...                           -0.541213
+# 2      1  ...              1   1.571164 ...                            0.032862
+# 3      1  ...              1   2.115638 ...                            0.537077
+# 4      0  ...              0 -23.038410 ...                           -0.682764

--- a/src/python/nimbusml/examples/PipelineWithFeatureContributions.py
+++ b/src/python/nimbusml/examples/PipelineWithFeatureContributions.py
@@ -7,10 +7,36 @@
 # computes a model-specific list of per-feature contributions to the score for
 # each example. These contributions can be positive (they make the score
 # higher) or negative (they make the score lower).
+#
+# Feature Contribution Calculation is currently supported for the following
+# models:
+#   - Regression:
+#     - OrdinaryLeastSquaresRegressor
+#     - FastLinearRegressor
+#     - OnlineGradientDescentRegressor
+#     - PoissonRegressionRegressor
+#     - GamRegressor
+#     - LightGbmRegressor
+#     - FastTreesRegressor
+#     - FastForestRegressor
+#     - FastTreesTweedieRegressor
+#   - Binary Classification:
+#     - AveragedPerceptronBinaryClassifier
+#     - LinearSvmBinaryClassifier
+#     - LogisticRegressionBinaryClassifier
+#     - FastLinearBinaryClassifier
+#     - SgdBinaryClassifier
+#     - SymSgdBinaryClassifier
+#     - GamBinaryClassifier
+#     - FastForestBinaryClassifier
+#     - FastTreesBinaryClassifier
+#     - LightGbmBinaryClassifier
+#   - Ranking:
+#     - LightGbmRanker
 
 from nimbusml import Pipeline, FileDataStream
 from nimbusml.datasets import get_dataset
-from nimbusml.linear_model import LogisticRegressionBinaryClassifier, PoissonRegressionRegressor
+from nimbusml.linear_model import LogisticRegressionBinaryClassifier
 from nimbusml.ensemble import FastTreesBinaryClassifier
 
 # data input (as a FileDataStream)
@@ -26,7 +52,7 @@ print(data.head())
 # 4      0          ?  Some-college  ...            0             30
 
 # define the training pipeline with a linear model
-lr_pipeline = Pipeline([PoissonRegressionRegressor(
+lr_pipeline = Pipeline([LogisticRegressionBinaryClassifier(
     feature=['age', 'education-num', 'hours-per-week'], label='label')])
 
 # train the model

--- a/src/python/nimbusml/examples/PipelineWithFeatureContributions.py
+++ b/src/python/nimbusml/examples/PipelineWithFeatureContributions.py
@@ -1,0 +1,37 @@
+###############################################################################
+# Pipeline with feature contributions
+from nimbusml import Pipeline, FileDataStream
+from nimbusml.datasets import get_dataset
+from nimbusml.linear_model import LogisticRegressionBinaryClassifier
+
+# data input (as a FileDataStream)
+path = get_dataset('uciadult_train').as_filepath()
+
+data = FileDataStream.read_csv(path)
+print(data.head())
+#    label  workclass     education  ... capital-loss hours-per-week
+# 0      0    Private          11th  ...            0             40
+# 1      0    Private       HS-grad  ...            0             50
+# 2      1  Local-gov    Assoc-acdm  ...            0             40
+# 3      1    Private  Some-college  ...            0             40
+# 4      0          ?  Some-college  ...            0             30
+# define the training pipeline
+pipeline = Pipeline([LogisticRegressionBinaryClassifier(
+    feature=['age', 'education-num', 'hours-per-week'], label='label')])
+
+# train, predict, and evaluate
+# TODO: Replace with CV
+model = pipeline.fit(data)
+
+feature_contributions = model.calculate_feature_contributions(
+    data, output_scores=True)
+
+# Print predictions with feature contributions, which give a relative measure
+# of how much each feature impacted the Score.
+print(feature_contributions.head())
+#   label  ... PredictedLabel     Score ... FeatureContributions.hours-per-week
+# 0        ...              0 -2.010687 ...                            0.833069
+# 1        ...              0 -1.216163 ...                            0.809928
+# 2        ...              0 -1.248412 ...                            0.485957
+# 3        ...              0 -1.132419 ...                            0.583148
+# 4        ...              0 -1.969522 ...                            0.437361

--- a/src/python/nimbusml/examples/PipelineWithFeatureContributions.py
+++ b/src/python/nimbusml/examples/PipelineWithFeatureContributions.py
@@ -1,8 +1,17 @@
 ###############################################################################
 # Pipeline with feature contributions
+
+# Scoring a dataset with a trained model produces a score, or prediction, for
+# each example. To understand and explain these predictions it can be useful to
+# inspect which features influenced them most significantly. This function
+# computes a model-specific list of per-feature contributions to the score for
+# each example. These contributions can be positive (they make the score
+# higher) or negative (they make the score lower).
+
 from nimbusml import Pipeline, FileDataStream
 from nimbusml.datasets import get_dataset
-from nimbusml.linear_model import LogisticRegressionBinaryClassifier
+from nimbusml.linear_model import LogisticRegressionBinaryClassifier, PoissonRegressionRegressor
+from nimbusml.ensemble import FastTreesBinaryClassifier
 
 # data input (as a FileDataStream)
 path = get_dataset('uciadult_train').as_filepath()
@@ -15,23 +24,56 @@ print(data.head())
 # 2      1  Local-gov    Assoc-acdm  ...            0             40
 # 3      1    Private  Some-college  ...            0             40
 # 4      0          ?  Some-college  ...            0             30
-# define the training pipeline
-pipeline = Pipeline([LogisticRegressionBinaryClassifier(
+
+# define the training pipeline with a linear model
+lr_pipeline = Pipeline([PoissonRegressionRegressor(
     feature=['age', 'education-num', 'hours-per-week'], label='label')])
 
-# train, predict, and evaluate
-# TODO: Replace with CV
-model = pipeline.fit(data)
+# train the model
+lr_model = lr_pipeline.fit(data)
 
-feature_contributions = model.calculate_feature_contributions(
-    data, output_scores=True)
+# For linear models, the contribution of a given feature is equal to the
+# product of feature value times the corresponding weight. Similarly, for
+# Generalized Additive Models (GAM), the contribution of a feature is equal to
+# the shape function for the given feature evaluated at the feature value.
+lr_feature_contributions = lr_model.get_feature_contributions(data)
 
 # Print predictions with feature contributions, which give a relative measure
 # of how much each feature impacted the Score.
-print(feature_contributions.head())
+print("========== Feature Contributions for Linear Model ==========")
+print(lr_feature_contributions.head())
 #   label  ... PredictedLabel     Score ... FeatureContributions.hours-per-week
 # 0        ...              0 -2.010687 ...                            0.833069
 # 1        ...              0 -1.216163 ...                            0.809928
 # 2        ...              0 -1.248412 ...                            0.485957
 # 3        ...              0 -1.132419 ...                            0.583148
 # 4        ...              0 -1.969522 ...                            0.437361
+
+# define the training pipeline with a tree model
+tree_pipeline = Pipeline([FastTreesBinaryClassifier(
+    feature=['age', 'education-num', 'hours-per-week'], label='label')])
+
+# train the model
+tree_model = tree_pipeline.fit(data)
+
+# For tree-based models, the calculation of feature contribution essentially
+# consists in determining which splits in the tree have the most impact on the
+# final score and assigning the value of the impact to the features determining
+# the split. More precisely, the contribution of a feature is equal to the
+# change in score produced by exploring the opposite sub-tree every time a
+# decision node for the given feature is encountered.
+# 
+# Consider a simple case with a single decision tree that has a decision node
+# for the binary feature F1. Given an example that has feature F1 equal to
+# true, we can calculate the score it would have obtained if we chose the
+# subtree corresponding to the feature F1 being equal to false while keeping
+# the other features constant. The contribution of feature F1 for the given
+# example is the difference between the original score and the score obtained
+# by taking the opposite decision at the node corresponding to feature F1. This
+#  algorithm extends naturally to models with many decision trees.
+tree_feature_contributions = tree_model.get_feature_contributions(data)
+
+# Print predictions with feature contributions, which give a relative measure
+# of how much each feature impacted the Score.
+print("========== Feature Contributions for Tree Model ==========")
+print(tree_feature_contributions.head())

--- a/src/python/nimbusml/examples/PipelineWithFeatureContributions.py
+++ b/src/python/nimbusml/examples/PipelineWithFeatureContributions.py
@@ -36,8 +36,8 @@
 
 from nimbusml import Pipeline, FileDataStream
 from nimbusml.datasets import get_dataset
-from nimbusml.linear_model import LogisticRegressionBinaryClassifier
 from nimbusml.ensemble import FastTreesBinaryClassifier
+from nimbusml.linear_model import LogisticRegressionBinaryClassifier
 
 # data input (as a FileDataStream)
 path = get_dataset('uciadult_train').as_filepath()
@@ -74,6 +74,9 @@ print(lr_feature_contributions.head())
 # 2        ...              0 -1.248412 ...                            0.485957
 # 3        ...              0 -1.132419 ...                            0.583148
 # 4        ...              0 -1.969522 ...                            0.437361
+
+assert 'FeatureContributions.age' in lr_feature_contributions.columns
+
 
 # define the training pipeline with a tree model
 tree_pipeline = Pipeline([FastTreesBinaryClassifier(

--- a/src/python/nimbusml/internal/core/base_pipeline_item.py
+++ b/src/python/nimbusml/internal/core/base_pipeline_item.py
@@ -15,6 +15,7 @@ import warnings
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from itertools import chain
+from shutil import copyfile
 from textwrap import wrap
 
 import six
@@ -446,6 +447,19 @@ class BasePipelineItem():
         if "columns" in pars:
             res["columns"] = pars
         return res
+
+    @trace
+    def save_model(self, dst):
+        """
+        Save model to file. For more details, please refer to
+        `load/save model </nimbusml/loadsavemodels>`_
+
+        :param dst: filename to be saved with
+
+        """
+        if self.model_ is not None:
+            if os.path.isfile(self.model_):
+                copyfile(self.model_, dst)
 
     def __getitem__(self, cols):
         """

--- a/src/python/nimbusml/internal/core/base_pipeline_item.py
+++ b/src/python/nimbusml/internal/core/base_pipeline_item.py
@@ -375,6 +375,8 @@ class BasePipelineItem():
     def __getstate__(self):
         "Selects what to pickle."
         odict = self.__dict__.copy()
+        odict['export_version'] = 1
+
         if hasattr(self, 'model_') and \
                 self.model_ is not None and os.path.isfile(self.model_):
             with open(self.model_, "rb") as mfile:
@@ -387,8 +389,11 @@ class BasePipelineItem():
     def __setstate__(self, state):
         "Restore a pickled object."
         for k, v in state.items():
-            if k not in {'modelbytes', 'type'}:
+            if k not in {'modelbytes', 'type', 'export_version'}:
                 setattr(self, k, v)
+
+        # Note: modelbytes and type were
+        # added before export_version 1
         if 'modelbytes' in state:
             (fd, modelfile) = tempfile.mkstemp()
             fl = os.fdopen(fd, "wb")

--- a/src/python/nimbusml/pipeline.py
+++ b/src/python/nimbusml/pipeline.py
@@ -1766,24 +1766,32 @@ class Pipeline:
             data="$data",
             predictor_model="$predictor_model",
             scored_data="$scoredvectordata")
-
-        fcc_node = transforms_featurecontributioncalculationtransformer(
-            data="$scoredvectordata",
-            predictor_model="$predictor_model",
-            output_data="$fccData",
-            top=top,
-            bottom=bottom,
-            normalize=True)
-        all_nodes.extend([score_node, fcc_node])
+        all_nodes.extend([score_node])
 
         if hasattr(self, 'steps') and len(self.steps) > 0 \
                 and self.last_node.type == 'classifier':
+            fcc_node = transforms_featurecontributioncalculationtransformer(
+                data="$scoredvectordata",
+                predictor_model="$predictor_model",
+                output_data="$fccData",
+                top=top,
+                bottom=bottom,
+                normalize=True)
             convert_label_node = \
                 transforms_predictedlabelcolumnoriginalvalueconverter(
                     data="$fccData",
                     predicted_label_column="PredictedLabel",
                     output_data="$output_data")
-            all_nodes.extend([convert_label_node])
+            all_nodes.extend([fcc_node, convert_label_node])
+        else:
+            fcc_node = transforms_featurecontributioncalculationtransformer(
+                data="$scoredvectordata",
+                predictor_model="$predictor_model",
+                output_data="$output_data",
+                top=top,
+                bottom=bottom,
+                normalize=True)
+            all_nodes.extend([fcc_node])
 
         outputs = dict(output_data="")
 

--- a/src/python/nimbusml/pipeline.py
+++ b/src/python/nimbusml/pipeline.py
@@ -1705,8 +1705,39 @@ class Pipeline:
                  verbose=0,
                  as_binary_data_stream=False, **params):
         """
-        Return dataframe with raw data, predictions, and feature contributiuons
-        for the predictions.
+        Calculates observation level feature contributions. Returns dataframe
+        with raw data, predictions, and feature contributiuons for each
+        prediction. Observation level feature contriutions are supported for
+        the following models:
+
+        * Regression:
+
+            * OrdinaryLeastSquaresRegressor
+            * FastLinearRegressor
+            * OnlineGradientDescentRegressor
+            * PoissonRegressionRegressor
+            * GamRegressor
+            * LightGbmRegressor
+            * FastTreesRegressor
+            * FastForestRegressor
+            * FastTreesTweedieRegressor
+
+        * Binary Classification:
+
+            * AveragedPerceptronBinaryClassifier
+            * LinearSvmBinaryClassifier
+            * LogisticRegressionBinaryClassifier
+            * FastLinearBinaryClassifier
+            * SgdBinaryClassifier
+            * SymSgdBinaryClassifier
+            * GamBinaryClassifier
+            * FastForestBinaryClassifier
+            * FastTreesBinaryClassifier
+            * LightGbmBinaryClassifier
+
+        * Ranking:
+
+            * LightGbmRanker
 
         :param X: {array-like [n_samples, n_features],
             :py:class:`nimbusml.FileDataStream` }
@@ -1766,32 +1797,16 @@ class Pipeline:
             data="$data",
             predictor_model="$predictor_model",
             scored_data="$scoredvectordata")
-        all_nodes.extend([score_node])
 
-        if hasattr(self, 'steps') and len(self.steps) > 0 \
-                and self.last_node.type == 'classifier':
-            fcc_node = transforms_featurecontributioncalculationtransformer(
-                data="$scoredvectordata",
-                predictor_model="$predictor_model",
-                output_data="$fccData",
-                top=top,
-                bottom=bottom,
-                normalize=True)
-            convert_label_node = \
-                transforms_predictedlabelcolumnoriginalvalueconverter(
-                    data="$fccData",
-                    predicted_label_column="PredictedLabel",
-                    output_data="$output_data")
-            all_nodes.extend([fcc_node, convert_label_node])
-        else:
-            fcc_node = transforms_featurecontributioncalculationtransformer(
-                data="$scoredvectordata",
-                predictor_model="$predictor_model",
-                output_data="$output_data",
-                top=top,
-                bottom=bottom,
-                normalize=True)
-            all_nodes.extend([fcc_node])
+        fcc_node = transforms_featurecontributioncalculationtransformer(
+            data="$scoredvectordata",
+            predictor_model="$predictor_model",
+            output_data="$output_data",
+            top=top,
+            bottom=bottom,
+            normalize=True)
+        
+        all_nodes.extend([score_node, fcc_node])
 
         outputs = dict(output_data="")
 

--- a/src/python/nimbusml/pipeline.py
+++ b/src/python/nimbusml/pipeline.py
@@ -41,6 +41,8 @@ from .internal.entrypoints.transforms_datasetscorer import \
     transforms_datasetscorer
 from .internal.entrypoints.transforms_featurecombiner import \
     transforms_featurecombiner
+from .internal.entrypoints.transforms_featurecontributioncalculationtransformer import \
+    transforms_featurecontributioncalculationtransformer
 from .internal.entrypoints.transforms_labelcolumnkeybooleanconverter \
     import \
     transforms_labelcolumnkeybooleanconverter
@@ -1693,6 +1695,122 @@ class Pipeline:
                     "If any step in the pipeline has defined Label, "
                     "only fit(X) is allowed or the training becomes "
                     "ambiguous.")
+
+    @trace
+    def calculate_feature_contributions(self, X, y=None,
+                 evaltype='auto', group_id=None,
+                 weight=None,
+                 verbose=0,
+                 top=10,
+                 bottom=10,
+                 normalize=True,
+                 as_binary_data_stream=False, **params):
+        """
+        Apply transforms and test with the final estimator, return metrics
+        """
+        # start the clock!
+        start_time = time.time()
+        self.verbose = verbose
+
+        if not self._is_fitted:
+            raise ValueError(
+                "Model is not fitted. Train or load a model before test("
+                ").")
+
+        if y is not None:
+            if len(self.steps) > 0:
+                last_node = self.last_node
+                if last_node.type == 'transform':
+                    raise ValueError(
+                        "Pipeline needs a trainer as last step for test()")
+
+        X, y_temp, columns_renamed, feature_columns, label_column, \
+            schema, weights, weight_column = self._preprocess_X_y(
+                X, y, w=weight
+            )
+
+        if (not isinstance(y, (str, tuple))) or (
+                isinstance(X, DataFrame) and isinstance(y, (str, tuple))):
+            y = y_temp
+
+        all_nodes = []
+        inputs = dict([('data', ''), ('predictor_model', self.model)])
+        if isinstance(X, FileDataStream):
+            importtext_node = data_customtextloader(
+                input_file="$file",
+                data="$data",
+                custom_schema=schema.to_string(
+                    add_sep=True))
+            all_nodes = [importtext_node]
+            inputs = dict([('file', ''), ('predictor_model', self.model)])
+
+        score_node = transforms_datasetscorer(
+            data="$data",
+            predictor_model="$predictor_model",
+            scored_data="$scoredvectordata")
+
+        fcc_node = transforms_featurecontributioncalculationtransformer(
+            data="$scoredvectordata",
+            predictor_model="$predictor_model",
+            output_data="$fccData",
+            top=top,
+            bottom=bottom,
+            normalize=normalize)
+        all_nodes.extend([score_node, fcc_node])
+
+        if hasattr(self, 'steps') and len(self.steps) > 0 \
+                and self.last_node.type == 'classifier':
+            convert_label_node = \
+                transforms_predictedlabelcolumnoriginalvalueconverter(
+                    data="$fccData",
+                    predicted_label_column="PredictedLabel",
+                    output_data="$output_data")
+            all_nodes.extend([convert_label_node])
+
+        if y is not None:
+            evaluate_nodes = self._evaluation_infer(
+                evaltype, label_column, group_id, **params)
+            for node in evaluate_nodes:
+                all_nodes.extend([node])
+            output_scores = '' if params.get(
+                'output_scores', False) else '<null>'
+            outputs = OrderedDict(
+                [('output_metrics', ''), ('output_data', output_scores)])
+        else:
+            outputs = dict(output_data="")
+
+        graph = Graph(
+            inputs,
+            outputs,
+            as_binary_data_stream,
+            *all_nodes)
+
+        class_name = type(self).__name__
+        method_name = inspect.currentframe().f_code.co_name
+        telemetry_info = ".".join([class_name, method_name])
+
+        try:
+            (out_model, out_data, out_metrics) = graph.run(
+                X=X,
+                y=y,
+                random_state=self.random_state,
+                model=self.model,
+                verbose=verbose,
+                telemetry_info=telemetry_info,
+                **params)
+        except RuntimeError as e:
+            self._run_time = time.time() - start_time
+            raise e
+
+        if y is not None:
+            # We need to fix the schema for ranking metrics
+            if evaltype == 'ranking':
+                out_metrics = self._fix_ranking_metrics_schema(out_metrics)
+
+        # stop the clock
+        self._run_time = time.time() - start_time
+        self._write_csv_time = graph._write_csv_time
+        return out_data
 
     @trace
     def _predict(self, X, y=None,

--- a/src/python/nimbusml/pipeline.py
+++ b/src/python/nimbusml/pipeline.py
@@ -1697,16 +1697,35 @@ class Pipeline:
                     "ambiguous.")
 
     @trace
-    def calculate_feature_contributions(self, X, y=None,
+    def get_feature_contributions(self, X, y=None,
                  evaltype='auto', group_id=None,
                  weight=None,
-                 verbose=0,
                  top=10,
                  bottom=10,
-                 normalize=True,
+                 verbose=0,
                  as_binary_data_stream=False, **params):
         """
-        Apply transforms and test with the final estimator, return metrics
+        Return dataframe with raw data, predictions, and feature contributiuons
+        for the predictions.
+
+        :param X: {array-like [n_samples, n_features],
+            :py:class:`nimbusml.FileDataStream` }
+        :param y: {array-like [n_samples]}
+
+        :param evaltype: the evaluation type for the problem, can be {
+            'binary', 'multiclass', 'regression', 'cluster', 'anomaly',
+            'ranking'}. The default is 'auto'. If model is loaded using the
+            load_model() method, evaltype cannot be 'auto', and therefore
+            must be explicitly specified.
+        :param group_id: the column name for group_id for ranking problem
+        :param weight: the column name for the weight column for each
+            sample.
+        :param top: the number of positive contributions with highest magnitude
+            to report.
+        :param bottom: The number of negative contributions with highest
+            magnitude to report.
+        :return: dataframe of containing the raw data, predicted label, score,
+            probabilities, and feature contributions.
         """
         # start the clock!
         start_time = time.time()
@@ -1755,7 +1774,7 @@ class Pipeline:
             output_data="$fccData",
             top=top,
             bottom=bottom,
-            normalize=normalize)
+            normalize=True)
         all_nodes.extend([score_node, fcc_node])
 
         if hasattr(self, 'steps') and len(self.steps) > 0 \
@@ -2061,7 +2080,7 @@ class Pipeline:
             otherwise None
             in the returned tuple.
         :return: tuple (dataframe of evaluation metrics, dataframe of
-            scores). Is scores are
+            scores). If scores are
             required, set `output_scores`=True, otherwise None is
             returned by default.
         """

--- a/src/python/nimbusml/pipeline.py
+++ b/src/python/nimbusml/pipeline.py
@@ -1727,8 +1727,6 @@ class Pipeline:
         :return: dataframe of containing the raw data, predicted label, score,
             probabilities, and feature contributions.
         """
-        # start the clock!
-        start_time = time.time()
         self.verbose = verbose
 
         if not self._is_fitted:
@@ -1736,6 +1734,7 @@ class Pipeline:
                 "Model is not fitted. Train or load a model before test("
                 ").")
 
+        #print(self.last_node.type)
         if y is not None:
             if len(self.steps) > 0:
                 last_node = self.last_node
@@ -1786,17 +1785,7 @@ class Pipeline:
                     output_data="$output_data")
             all_nodes.extend([convert_label_node])
 
-        if y is not None:
-            evaluate_nodes = self._evaluation_infer(
-                evaltype, label_column, group_id, **params)
-            for node in evaluate_nodes:
-                all_nodes.extend([node])
-            output_scores = '' if params.get(
-                'output_scores', False) else '<null>'
-            outputs = OrderedDict(
-                [('output_metrics', ''), ('output_data', output_scores)])
-        else:
-            outputs = dict(output_data="")
+        outputs = dict(output_data="")
 
         graph = Graph(
             inputs,
@@ -1818,17 +1807,8 @@ class Pipeline:
                 telemetry_info=telemetry_info,
                 **params)
         except RuntimeError as e:
-            self._run_time = time.time() - start_time
             raise e
 
-        if y is not None:
-            # We need to fix the schema for ranking metrics
-            if evaltype == 'ranking':
-                out_metrics = self._fix_ranking_metrics_schema(out_metrics)
-
-        # stop the clock
-        self._run_time = time.time() - start_time
-        self._write_csv_time = graph._write_csv_time
         return out_data
 
     @trace

--- a/src/python/nimbusml/pipeline.py
+++ b/src/python/nimbusml/pipeline.py
@@ -1702,14 +1702,9 @@ class Pipeline:
         """
         Calculates observation level feature contributions. Returns dataframe
         with raw data, predictions, and feature contributiuons for each
-<<<<<<< HEAD
         prediction. Feature contributions are not supported for transforms, so
         make sure that the last step in a pipeline is a model. Feature
         contriutions are supported for the following models:
-=======
-        prediction. Observation level feature contriutions are supported for
-        the following models:
->>>>>>> 93a46fa251ec5fb0b19d162a21c8780fb75e659a
 
         * Regression:
 
@@ -1755,14 +1750,6 @@ class Pipeline:
             raise ValueError(
                 "Model is not fitted. Train or load a model before test().")
 
-<<<<<<< HEAD
-=======
-        # BUG: If model is loaded from zip file, self.steps is an empty array
-        # so this condition will always evaluate to False. Consequently, this
-        # code will never check if the last node is a transform or not. In any
-        # case, self.last_node will not exist if a model is loaded from zip so
-        # we could not check for it outside of this condition.
->>>>>>> 93a46fa251ec5fb0b19d162a21c8780fb75e659a
         if len(self.steps) > 0:
             last_node = self.last_node
             if last_node.type == 'transform':

--- a/src/python/nimbusml/pipeline.py
+++ b/src/python/nimbusml/pipeline.py
@@ -1702,8 +1702,9 @@ class Pipeline:
         """
         Calculates observation level feature contributions. Returns dataframe
         with raw data, predictions, and feature contributiuons for each
-        prediction. Observation level feature contriutions are supported for
-        the following models:
+        prediction. Feature contributions are not supported for transforms, so
+        make sure that the last step in a pipeline is a model. Feature
+        contriutions are supported for the following models:
 
         * Regression:
 
@@ -1749,11 +1750,6 @@ class Pipeline:
             raise ValueError(
                 "Model is not fitted. Train or load a model before test().")
 
-        # BUG: If model is loaded from zip file, self.steps is an empty array
-        # so this condition will always evaluate to False. Consequently, this
-        # code will never check if the last node is a transform or not. In any
-        # case, self.last_node will not exist if a model is loaded from zip so
-        # we could not check for it outside of this condition.
         if len(self.steps) > 0:
             last_node = self.last_node
             if last_node.type == 'transform':

--- a/src/python/nimbusml/pipeline.py
+++ b/src/python/nimbusml/pipeline.py
@@ -1697,13 +1697,8 @@ class Pipeline:
                     "ambiguous.")
 
     @trace
-    def get_feature_contributions(self, X, y=None,
-                 evaltype='auto', group_id=None,
-                 weight=None,
-                 top=10,
-                 bottom=10,
-                 verbose=0,
-                 as_binary_data_stream=False, **params):
+    def get_feature_contributions(self, X, top=10, bottom=10, verbose=0, 
+                                  as_binary_data_stream=False, **params):
         """
         Calculates observation level feature contributions. Returns dataframe
         with raw data, predictions, and feature contributiuons for each
@@ -1741,16 +1736,6 @@ class Pipeline:
 
         :param X: {array-like [n_samples, n_features],
             :py:class:`nimbusml.FileDataStream` }
-        :param y: {array-like [n_samples]}
-
-        :param evaltype: the evaluation type for the problem, can be {
-            'binary', 'multiclass', 'regression', 'cluster', 'anomaly',
-            'ranking'}. The default is 'auto'. If model is loaded using the
-            load_model() method, evaltype cannot be 'auto', and therefore
-            must be explicitly specified.
-        :param group_id: the column name for group_id for ranking problem
-        :param weight: the column name for the weight column for each
-            sample.
         :param top: the number of positive contributions with highest magnitude
             to report.
         :param bottom: The number of negative contributions with highest
@@ -1762,25 +1747,21 @@ class Pipeline:
 
         if not self._is_fitted:
             raise ValueError(
-                "Model is not fitted. Train or load a model before test("
-                ").")
+                "Model is not fitted. Train or load a model before test().")
 
-        #print(self.last_node.type)
-        if y is not None:
-            if len(self.steps) > 0:
-                last_node = self.last_node
-                if last_node.type == 'transform':
-                    raise ValueError(
-                        "Pipeline needs a trainer as last step for test()")
+        # BUG: If model is loaded from zip file, self.steps is an empty array
+        # so this condition will always evaluate to False. Consequently, this
+        # code will never check if the last node is a transform or not. In any
+        # case, self.last_node will not exist if a model is loaded from zip so
+        # we could not check for it outside of this condition.
+        if len(self.steps) > 0:
+            last_node = self.last_node
+            if last_node.type == 'transform':
+                raise ValueError(
+                    "Pipeline needs a trainer as last step for test()")
 
         X, y_temp, columns_renamed, feature_columns, label_column, \
-            schema, weights, weight_column = self._preprocess_X_y(
-                X, y, w=weight
-            )
-
-        if (not isinstance(y, (str, tuple))) or (
-                isinstance(X, DataFrame) and isinstance(y, (str, tuple))):
-            y = y_temp
+            schema, weights, weight_column = self._preprocess_X_y(X)
 
         all_nodes = []
         inputs = dict([('data', ''), ('predictor_model', self.model)])
@@ -1823,7 +1804,6 @@ class Pipeline:
         try:
             (out_model, out_data, out_metrics) = graph.run(
                 X=X,
-                y=y,
                 random_state=self.random_state,
                 model=self.model,
                 verbose=verbose,

--- a/src/python/nimbusml/tests/pipeline/test_load_save.py
+++ b/src/python/nimbusml/tests/pipeline/test_load_save.py
@@ -149,21 +149,10 @@ class TestLoadSave(unittest.TestCase):
         model_nimbusml.fit(train, label)
         metrics, score = model_nimbusml.test(test, test_label, output_scores=True)
 
-        pickle_filename = 'nimbusml_model.p'
-
-        # Save with pickle
-        with open(pickle_filename, 'wb') as f:
-            pickle.dump(model_nimbusml, f)
-
         # Remove the pipeline model from disk so
         # that the unpickled pipeline is forced
         # to get its model from the pickled file.
         os.remove(model_nimbusml.model)
-
-        with open(pickle_filename, "rb") as f:
-            model_nimbusml_pickle = pickle.load(f)
-
-        os.remove(pickle_filename)
 
         metrics_pickle, score_pickle = model_nimbusml_pickle.test(
             test, test_label, output_scores=True)

--- a/src/python/nimbusml/tests/pipeline/test_load_save.py
+++ b/src/python/nimbusml/tests/pipeline/test_load_save.py
@@ -7,7 +7,7 @@ import os
 import pickle
 import unittest
 
-from nimbusml import Pipeline
+from nimbusml import Pipeline, FileDataStream
 from nimbusml.datasets import get_dataset
 from nimbusml.feature_extraction.categorical import OneHotVectorizer
 from nimbusml.linear_model import FastLinearBinaryClassifier
@@ -211,6 +211,30 @@ class TestLoadSave(unittest.TestCase):
                             metrics_pickle.sum().sum(),
                             decimal=2)
 
+
+    def test_pipeline_loaded_from_zip_has_feature_contributions(self):
+        features = ['age', 'education-num', 'hours-per-week']
+        
+        model_nimbusml = Pipeline(
+            steps=[FastLinearBinaryClassifier(feature=features)])
+
+        model_nimbusml.fit(train, label)
+
+        # Save the model to zip
+        model_filename = 'nimbusml_model.zip'
+        model_nimbusml.save_model(model_filename)
+
+        # Load the model from zip
+        model_nimbusml_zip = Pipeline()
+        model_nimbusml_zip.load_model(model_filename)
+
+        feature_contributions = model_nimbusml_zip.get_feature_contributions(
+            test, test_label)
+
+        os.remove(model_filename)
+
+        assert ['FeatureContributions.' + feature in feature_contributions.columns
+                for feature in features]
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/python/nimbusml/tests/pipeline/test_load_save.py
+++ b/src/python/nimbusml/tests/pipeline/test_load_save.py
@@ -7,7 +7,7 @@ import os
 import pickle
 import unittest
 
-from nimbusml import Pipeline, FileDataStream
+from nimbusml import Pipeline
 from nimbusml.datasets import get_dataset
 from nimbusml.feature_extraction.categorical import OneHotVectorizer
 from nimbusml.linear_model import FastLinearBinaryClassifier

--- a/src/python/nimbusml/tests/scikit/test_uci_adult_scikit.py
+++ b/src/python/nimbusml/tests/scikit/test_uci_adult_scikit.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------------------------
 
+import os
 import pickle
 import unittest
 
@@ -111,6 +112,7 @@ class TestUciAdultScikit(unittest.TestCase):
         # Unpickle model and score. We should get the exact same accuracy as
         # above
         s = pickle.dumps(ftree)
+        os.remove(ftree.model_)
         ftree2 = pickle.loads(s)
         scores2 = ftree2.predict(X_test)
         accu2 = np.mean(y_test.values.ravel() == scores2.values)
@@ -130,6 +132,7 @@ class TestUciAdultScikit(unittest.TestCase):
         # Unpickle transform and generate output.
         # We should get the exact same output as above
         s = pickle.dumps(cat)
+        os.remove(cat.model_)
         cat2 = pickle.loads(s)
         out2 = cat2.transform(X_train)
         assert_equal(
@@ -158,7 +161,10 @@ class TestUciAdultScikit(unittest.TestCase):
         # Unpickle model and score. We should get the exact same accuracy as
         # above
         s = pickle.dumps(pipe)
+        os.remove(cat.model_)
+        os.remove(ftree.model_)
         pipe2 = pickle.loads(s)
+
         scores2 = pipe2.predict(X_test)
         accu2 = np.mean(y_test.values.ravel() == scores2.values)
         assert_equal(


### PR DESCRIPTION
Fix #91 

Adds a `get_feature_contributions()` method to `Pipeline`, which works similarly to `predict()` but adds a `transforms_featurecontributioncalculationtransformer` node after the `transforms_datasetscorer` node in the graph that gets executed.

Adds a `get_feature_contributions()` method to `BasePredictor` so that models trained outside of a `Pipeline` also return feature contributions.

Adds an example of how to use this.

Adds a test to check that an unpickled model can calculate feature contributions.

Adds a test to check that a model loaded from zip can calculate feature contributions.