### PR TITLE
Add --installPythonPackages flag to build scripts

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -21,6 +21,7 @@ set BoostRoot=%DependenciesDir%BoostDbg3.7
 set PythonVersion=3.7
 set PythonTag=cp37
 set RunTests=False
+set InstallPythonPackages=False
 set RunExtendedTests=False
 set BuildDotNetBridgeOnly=False
 set SkipDotNetBridge=False
@@ -33,6 +34,11 @@ if /i [%1] == [--configuration] (
 )
 if /i [%1] == [--runTests]     (
     set RunTests=True
+    set InstallPythonPackages=True
+    shift && goto :Arg_Loop
+)
+if /i [%1] == [--installPythonPackages]     (
+    set InstallPythonPackages=True
     shift && goto :Arg_Loop
 )
 if /i [%1] == [--includeExtendedTests]     (
@@ -58,6 +64,7 @@ echo ""
 echo "Options:"
 echo "  --configuration <Configuration>   Build Configuration (DbgWinPy3.7,DbgWinPy3.6,DbgWinPy3.5,DbgWinPy2.7,RlsWinPy3.7,RlsWinPy3.6,RlsWinPy3.5,RlsWinPy2.7)"
 echo "  --runTests                        Run tests after build"
+echo "  --installPythonPackages           Install python packages after build"
 echo "  --includeExtendedTests            Include the extended tests if the tests are run"
 echo "  --buildDotNetBridgeOnly           Build only DotNetBridge"
 echo "  --skipDotNetBridge                Build everything except DotNetBridge"
@@ -328,6 +335,19 @@ md "%__currentScriptDir%target"
 copy "%__currentScriptDir%src\python\dist\%WheelFile%" "%__currentScriptDir%target\%WheelFile%"
 echo Python package successfully created: %__currentScriptDir%target\%WheelFile%
 
+if "%InstallPythonPackages%" == "True" (
+    echo ""
+    echo "#################################"
+    echo "Installing python packages ... "
+    echo "#################################"
+    call "%PythonExe%" -m pip install --upgrade nose pytest graphviz imageio pytest-cov "jupyter_client>=4.4.0" "nbconvert>=4.2.0"
+    if %PythonVersion% == 2.7 ( call "%PythonExe%" -m pip install --upgrade pyzmq )
+    :: Run azureml-dataprep tests only in pyhon 3.7 as its an optional dependency
+    if %PythonVersion% == 3.7 ( call "%PythonExe%" -m pip install --upgrade azureml-dataprep )
+    call "%PythonExe%" -m pip install --upgrade "%__currentScriptDir%target\%WheelFile%"
+    call "%PythonExe%" -m pip install "scikit-learn==0.19.2"
+)
+
 if "%RunTests%" == "False" ( 
     goto :Exit_Success
 )
@@ -337,13 +357,6 @@ echo ""
 echo "#################################"
 echo "Running tests ... "
 echo "#################################"
-call "%PythonExe%" -m pip install --upgrade nose pytest graphviz imageio pytest-cov "jupyter_client>=4.4.0" "nbconvert>=4.2.0"
-if %PythonVersion% == 2.7 ( call "%PythonExe%" -m pip install --upgrade pyzmq )
-:: Run azureml-dataprep tests only in pyhon 3.7 as its an optional dependency
-if %PythonVersion% == 3.7 ( call "%PythonExe%" -m pip install --upgrade azureml-dataprep )
-call "%PythonExe%" -m pip install --upgrade "%__currentScriptDir%target\%WheelFile%"
-call "%PythonExe%" -m pip install "scikit-learn==0.19.2"
-
 set PackagePath=%PythonRoot%\Lib\site-packages\nimbusml
 set TestsPath1=%PackagePath%\tests
 set TestsPath2=%__currentScriptDir%src\python\tests

--- a/build.sh
+++ b/build.sh
@@ -62,6 +62,7 @@ while [ "$1" != "" ]; do
             __buildNativeBridge=false
             __buildDotNetBridge=false
             __runTests=true
+            __installPythonPackages=true
             ;;
         --buildnativebridgeonly)
             __buildDotNetBridge=false

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ usage()
     echo "Options:"
     echo "  --configuration <Configuration>   Build Configuration (DbgLinPy3.7,DbgLinPy3.6,DbgLinPy3.5,DbgLinPy2.7,RlsLinPy3.7,RlsLinPy3.6,RlsLinPy3.5,RlsLinPy2.7,DbgMacPy3.7,DbgMacPy3.6,DbgMacPy3.5,DbgMacPy2.7,RlsMacPy3.7,RlsMacPy3.6,RlsMacPy3.5,RlsMacPy2.7)"
     echo "  --runTests                        Run tests after build"
+    echo "  --installPythonPackages           Install python packages after build"
     echo "  --runTestsOnly                    Run tests on a wheel file in default build location (<repo>/target/)"
     echo "  --includeExtendedTests            Include the extended tests if the tests are run"
     echo "  --buildNativeBridgeOnly           Build only the native bridge code"
@@ -31,6 +32,7 @@ else
     __configuration=DbgLinPy3.7
 fi
 __runTests=false
+__installPythonPackages=false
 __runExtendedTests=false
 __buildNativeBridge=true
 __buildDotNetBridge=true
@@ -48,6 +50,10 @@ while [ "$1" != "" ]; do
             ;;
         --runtests)
             __runTests=true
+            __installPythonPackages=true
+            ;;
+        --installPythonPackages)
+            __installPythonPackages=true
             ;;
         --includeextendedtests)
             __runExtendedTests=true
@@ -247,11 +253,11 @@ then
     echo Python package successfully created: ${__currentScriptDir}/target/${WheelFile}
 fi
 
-if [ ${__runTests} = true ]
-then 
+if [ ${__installPythonPackages} = true ]
+then
     echo ""
     echo "#################################"
-    echo "Running tests ... "
+    echo "Installing Python packages ... "
     echo "#################################"
     Wheel=${__currentScriptDir}/target/nimbusml-${ProductVersion}-${PythonTag}-none-${PlatName}.whl
     if [ ! -f ${Wheel} ]
@@ -274,6 +280,12 @@ then
     "${PythonExe}" -m pip install --upgrade "${Wheel}"
     "${PythonExe}" -m pip install "scikit-learn==0.19.2"
 
+if [ ${__runTests} = true ]
+then 
+    echo ""
+    echo "#################################"
+    echo "Running tests ... "
+    echo "#################################"
     PackagePath=${PythonRoot}/lib/python${PythonVersion}/site-packages/nimbusml
     TestsPath1=${PackagePath}/tests
     TestsPath2=${__currentScriptDir}/src/python/tests

--- a/build.sh
+++ b/build.sh
@@ -279,6 +279,7 @@ then
 	fi
     "${PythonExe}" -m pip install --upgrade "${Wheel}"
     "${PythonExe}" -m pip install "scikit-learn==0.19.2"
+fi
 
 if [ ${__runTests} = true ]
 then 


### PR DESCRIPTION
In order to install packages such as `six`, `numpy`, `scipy`, and `sklearn` in `dependencies\Python3.7`, we need to run `build --runTests` at least once for a fresh enlistment.

However, if we do a `git clean` after doing this, the python installation is removed and `build --runTests` needs to be run after every `git clean` in order to get those packages. I may want to only run some examples without running tests, e.g. examples for a new feature I'm working on, for which those packages are needed.

This PR adds a flag to install python packages without having to run tests to address this use case.