### PR TITLE
Fix a bug with the classes_ attribute when no y input is specified during fitting.

### DIFF
--- a/src/python/nimbusml/pipeline.py
+++ b/src/python/nimbusml/pipeline.py
@@ -1913,9 +1913,10 @@ class Pipeline:
             self._add_classes(unique_classes)
 
     def _extract_classes_from_headers(self, headers):
-        classes = [x.replace('Score.', '') for x in headers]
-        classes = np.array(classes).astype(self.last_node.classes_.dtype)
-        self._add_classes(classes)
+        if hasattr(self.last_node, 'classes_'):
+            classes = [x.replace('Score.', '') for x in headers]
+            classes = np.array(classes).astype(self.last_node.classes_.dtype)
+            self._add_classes(classes)
 
     def _add_classes(self, classes):
         # Create classes_ attribute similar to scikit

--- a/src/python/nimbusml/tests/pipeline/test_predict_proba_decision_function.py
+++ b/src/python/nimbusml/tests/pipeline/test_predict_proba_decision_function.py
@@ -155,7 +155,7 @@ class TestPredictProba(unittest.TestCase):
 
     def test_predict_proba_multiclass_3class_no_y_input_implies_no_classes_attribute(self):
         X_train = X_train_3class_int.join(y_train_3class_int)
-        X_test = X_test_3class_int.join(y_test_3class_int)
+        X_test = X_test_3class_int.join(y_test_3class_int) 
 
         clf = FastLinearClassifier(number_of_threads=1, label='Label')
         clf.fit(X_train)

--- a/src/python/nimbusml/tests/pipeline/test_predict_proba_decision_function.py
+++ b/src/python/nimbusml/tests/pipeline/test_predict_proba_decision_function.py
@@ -120,7 +120,7 @@ class TestPredictProba(unittest.TestCase):
             s,
             38.0,
             decimal=4,
-            err_msg=invalid_decision_function_output)
+            err_msg=invalid_predict_proba_output)
         assert_equal(set(clf.classes_), {'Blue', 'Green', 'Red'})
 
     def test_pass_predict_proba_multiclass_with_pipeline_adds_classes(self):
@@ -137,7 +137,7 @@ class TestPredictProba(unittest.TestCase):
             s,
             38.0,
             decimal=4,
-            err_msg=invalid_decision_function_output)
+            err_msg=invalid_predict_proba_output)
 
         assert_equal(set(clf.classes_),  expected_classes)
         assert_equal(set(pipeline.classes_),  expected_classes)
@@ -150,8 +150,33 @@ class TestPredictProba(unittest.TestCase):
             s,
             38.0,
             decimal=4,
-            err_msg=invalid_decision_function_output)
+            err_msg=invalid_predict_proba_output)
         assert_equal(set(clf.classes_), {0, 1, 2})
+
+    def test_predict_proba_multiclass_3class_no_y_input_implies_no_classes_attribute(self):
+        X_train = X_train_3class_int.join(y_train_3class_int)
+        X_test = X_test_3class_int.join(y_test_3class_int)
+
+        clf = FastLinearClassifier(number_of_threads=1, label='Label')
+        clf.fit(X_train)
+
+        if hasattr(clf, 'classes_'):
+            # The classes_ attribute is currently not supported
+            # when fitting when there is no y input specified.
+            self.fail("classes_ attribute not expected.")
+
+        s = clf.predict_proba(X_test).sum()
+        assert_almost_equal(
+            s,
+            38.0,
+            decimal=4,
+            err_msg=invalid_predict_proba_output)
+
+        if hasattr(clf, 'classes_'):
+            # The classes_ attribute is currently not supported
+            # when predicting when there was no y input specified
+            # during fitting.
+            self.fail("classes_ attribute not expected.")
 
     def test_fail_predict_proba_multiclass_with_pipeline(self):
         check_unsupported_predict_proba(self, Pipeline(
@@ -241,6 +266,31 @@ class TestDecisionFunction(unittest.TestCase):
             decimal=4,
             err_msg=invalid_decision_function_output)
         assert_equal(set(clf.classes_), {0, 1, 2})
+
+    def test_decision_function_multiclass_3class_no_y_input_implies_no_classes_attribute(self):
+        X_train = X_train_3class_int.join(y_train_3class_int)
+        X_test = X_test_3class_int.join(y_test_3class_int)
+
+        clf = FastLinearClassifier(number_of_threads=1, label='Label')
+        clf.fit(X_train)
+
+        if hasattr(clf, 'classes_'):
+            # The classes_ attribute is currently not supported
+            # when fitting when there is no y input specified.
+            self.fail("classes_ attribute not expected.")
+
+        s = clf.decision_function(X_test).sum()
+        assert_almost_equal(
+            s,
+            38.0,
+            decimal=4,
+            err_msg=invalid_decision_function_output)
+
+        if hasattr(clf, 'classes_'):
+            # The classes_ attribute is currently not supported
+            # when predicting when there was no y input specified
+            # during fitting.
+            self.fail("classes_ attribute not expected.")
 
     def test_fail_decision_function_multiclass(self):
         check_unsupported_decision_function(


### PR DESCRIPTION
No longer add a `classes_` attribute during prediction when no `y` input is specified during fitting because the type can not be determined. Previously, in this scenario, the `classes_` attribute after prediction contained values of type string even if the training labels were of type `int` or `float`.

A `y` input must be specified for the `classes_` attribute feature to work.

Fixes #216 

This is a quick fix which addresses issue #216. The more complete fix would be to support a `classes_` attribute when _no_ `y` input is specified. The classes should be extracted from the labels column in the `X` input.