### PR TITLE
Change Linear SVM lambda_ parameter to regularization

### DIFF
--- a/src/python/nimbusml/internal/core/linear_model/linearsvmbinaryclassifier.py
+++ b/src/python/nimbusml/internal/core/linear_model/linearsvmbinaryclassifier.py
@@ -69,7 +69,7 @@ class LinearSvmBinaryClassifier(
 
     :param caching: Whether trainer should cache input training data.
 
-    :param lambda_: Regularizer constant.
+    :param regularization: Regularizer constant.
 
     :param perform_projection: Perform projection to unit-ball? Typically used
         with batch size > 1.
@@ -105,7 +105,7 @@ class LinearSvmBinaryClassifier(
             self,
             normalize='Auto',
             caching='Auto',
-            lambda_=0.001,
+            regularization=0.001,
             perform_projection=False,
             number_of_iterations=1,
             initial_weights_diameter=0.0,
@@ -119,7 +119,7 @@ class LinearSvmBinaryClassifier(
 
         self.normalize = normalize
         self.caching = caching
-        self.lambda_ = lambda_
+        self.regularization = regularization
         self.perform_projection = perform_projection
         self.number_of_iterations = number_of_iterations
         self.initial_weights_diameter = initial_weights_diameter
@@ -146,7 +146,7 @@ class LinearSvmBinaryClassifier(
                 all_args),
             normalize_features=self.normalize,
             caching=self.caching,
-            lambda_=self.lambda_,
+            regularization=self.regularization,
             perform_projection=self.perform_projection,
             number_of_iterations=self.number_of_iterations,
             initial_weights_diameter=self.initial_weights_diameter,

--- a/src/python/nimbusml/internal/core/linear_model/linearsvmbinaryclassifier.py
+++ b/src/python/nimbusml/internal/core/linear_model/linearsvmbinaryclassifier.py
@@ -69,7 +69,9 @@ class LinearSvmBinaryClassifier(
 
     :param caching: Whether trainer should cache input training data.
 
-    :param regularization: Regularizer constant.
+    :param l2_regularization: L2 regularization weight. This also controls the
+        learning rate, with the learning rate being inversely proportional to
+        the regularization weight.
 
     :param perform_projection: Perform projection to unit-ball? Typically used
         with batch size > 1.
@@ -105,7 +107,7 @@ class LinearSvmBinaryClassifier(
             self,
             normalize='Auto',
             caching='Auto',
-            regularization=0.001,
+            l2_regularization=0.001,
             perform_projection=False,
             number_of_iterations=1,
             initial_weights_diameter=0.0,
@@ -119,7 +121,7 @@ class LinearSvmBinaryClassifier(
 
         self.normalize = normalize
         self.caching = caching
-        self.regularization = regularization
+        self.l2_regularization = l2_regularization
         self.perform_projection = perform_projection
         self.number_of_iterations = number_of_iterations
         self.initial_weights_diameter = initial_weights_diameter
@@ -146,7 +148,7 @@ class LinearSvmBinaryClassifier(
                 all_args),
             normalize_features=self.normalize,
             caching=self.caching,
-            regularization=self.regularization,
+            lambda_=self.l2_regularization,
             perform_projection=self.perform_projection,
             number_of_iterations=self.number_of_iterations,
             initial_weights_diameter=self.initial_weights_diameter,
@@ -157,3 +159,4 @@ class LinearSvmBinaryClassifier(
 
         all_args.update(algo_args)
         return self._entrypoint(**all_args)
+ 

--- a/src/python/nimbusml/internal/entrypoints/trainers_linearsvmbinaryclassifier.py
+++ b/src/python/nimbusml/internal/entrypoints/trainers_linearsvmbinaryclassifier.py
@@ -17,7 +17,7 @@ def trainers_linearsvmbinaryclassifier(
         example_weight_column_name=None,
         normalize_features='Auto',
         caching='Auto',
-        lambda_=0.001,
+        regularization=0.001,
         perform_projection=False,
         number_of_iterations=1,
         initial_weights_diameter=0.0,
@@ -41,7 +41,7 @@ def trainers_linearsvmbinaryclassifier(
         column (inputs).
     :param caching: Whether trainer should cache input training data
         (inputs).
-    :param lambda_: Regularizer constant (inputs).
+    :param regularization: Regularizer constant (inputs).
     :param perform_projection: Perform projection to unit-ball?
         Typically used with batch size > 1. (inputs).
     :param number_of_iterations: Number of iterations (inputs).
@@ -105,9 +105,9 @@ def trainers_linearsvmbinaryclassifier(
                 'Auto',
                 'Memory',
                 'None'])
-    if lambda_ is not None:
+    if regularization is not None:
         inputs['Lambda'] = try_set(
-            obj=lambda_,
+            obj=regularization,
             none_acceptable=True,
             is_of_type=numbers.Real)
     if perform_projection is not None:

--- a/src/python/nimbusml/internal/entrypoints/trainers_linearsvmbinaryclassifier.py
+++ b/src/python/nimbusml/internal/entrypoints/trainers_linearsvmbinaryclassifier.py
@@ -17,7 +17,7 @@ def trainers_linearsvmbinaryclassifier(
         example_weight_column_name=None,
         normalize_features='Auto',
         caching='Auto',
-        regularization=0.001,
+        lambda_=0.001,
         perform_projection=False,
         number_of_iterations=1,
         initial_weights_diameter=0.0,
@@ -41,7 +41,7 @@ def trainers_linearsvmbinaryclassifier(
         column (inputs).
     :param caching: Whether trainer should cache input training data
         (inputs).
-    :param regularization: Regularizer constant (inputs).
+    :param lambda_: Regularizer constant (inputs).
     :param perform_projection: Perform projection to unit-ball?
         Typically used with batch size > 1. (inputs).
     :param number_of_iterations: Number of iterations (inputs).
@@ -105,9 +105,9 @@ def trainers_linearsvmbinaryclassifier(
                 'Auto',
                 'Memory',
                 'None'])
-    if regularization is not None:
+    if lambda_ is not None:
         inputs['Lambda'] = try_set(
-            obj=regularization,
+            obj=lambda_,
             none_acceptable=True,
             is_of_type=numbers.Real)
     if perform_projection is not None:

--- a/src/python/nimbusml/linear_model/linearsvmbinaryclassifier.py
+++ b/src/python/nimbusml/linear_model/linearsvmbinaryclassifier.py
@@ -78,7 +78,7 @@ class LinearSvmBinaryClassifier(
 
     :param caching: Whether trainer should cache input training data.
 
-    :param lambda_: Regularizer constant.
+    :param regularization: Regularizer constant.
 
     :param perform_projection: Perform projection to unit-ball? Typically used
         with batch size > 1.
@@ -114,7 +114,7 @@ class LinearSvmBinaryClassifier(
             self,
             normalize='Auto',
             caching='Auto',
-            lambda_=0.001,
+            regularization=0.001,
             perform_projection=False,
             number_of_iterations=1,
             initial_weights_diameter=0.0,
@@ -147,7 +147,7 @@ class LinearSvmBinaryClassifier(
             self,
             normalize=normalize,
             caching=caching,
-            lambda_=lambda_,
+            regularization=regularization,
             perform_projection=perform_projection,
             number_of_iterations=number_of_iterations,
             initial_weights_diameter=initial_weights_diameter,

--- a/src/python/nimbusml/linear_model/linearsvmbinaryclassifier.py
+++ b/src/python/nimbusml/linear_model/linearsvmbinaryclassifier.py
@@ -78,7 +78,9 @@ class LinearSvmBinaryClassifier(
 
     :param caching: Whether trainer should cache input training data.
 
-    :param regularization: Regularizer constant.
+    :param l2_regularization: L2 regularization weight. This also controls the
+        learning rate, with the learning rate being inversely proportional to
+        the regularization weight.
 
     :param perform_projection: Perform projection to unit-ball? Typically used
         with batch size > 1.
@@ -114,7 +116,7 @@ class LinearSvmBinaryClassifier(
             self,
             normalize='Auto',
             caching='Auto',
-            regularization=0.001,
+            l2_regularization=0.001,
             perform_projection=False,
             number_of_iterations=1,
             initial_weights_diameter=0.0,
@@ -147,7 +149,7 @@ class LinearSvmBinaryClassifier(
             self,
             normalize=normalize,
             caching=caching,
-            regularization=regularization,
+            l2_regularization=l2_regularization,
             perform_projection=perform_projection,
             number_of_iterations=number_of_iterations,
             initial_weights_diameter=initial_weights_diameter,

--- a/src/python/tools/manifest_diff.json
+++ b/src/python/tools/manifest_diff.json
@@ -241,7 +241,13 @@
       "Module": "linear_model",
       "Type": "Classifier",
       "Predict_Proba" : true,
-      "Decision_Function" : true
+      "Decision_Function" : true,
+      "Inputs": [{
+        "Name": "Lambda",
+        "NewName": "l2_regularization",
+        "Desc": "L2 regularization weight. This also controls the learning rate, with the learning rate being inversely proportional to the regularization weight."
+      }
+      ]
     },
     {
       "Name": "Trainers.EnsembleClassification",


### PR DESCRIPTION
Fixes #254 

The recently added Linear SVM learner uses the parameter name `lambda_` to avoid Python reserved word conflicts with `lambda`. This PR changes `lambda_` to `l2_regularization`. This is more descriptive and avoids confusion where the trailing underscore could be mistaken as indicating a private variable.