### PR TITLE
Update Schema.py to remove the non-ASCII character

### DIFF
--- a/src/python/nimbusml/examples/Schema.py
+++ b/src/python/nimbusml/examples/Schema.py
@@ -30,4 +30,4 @@ pipe.fit(data)
 schema = pipe.get_schema()
 
 print(schema[0:5])
-# ['Sentiment', 'SentimentText', 'features.Char.<␂>|=|=', 'features.Char.=|=|r', 'features.Char.=|r|u']
+# ['Sentiment', 'SentimentText', 'features.Char.<?>|=|=', 'features.Char.=|=|r', 'features.Char.=|r|u']


### PR DESCRIPTION
Fixes #289 

Replaced the non-ASCII character `␂`, which was causing NimbusML-ExtendedTests to fail on Python 2.7 on Windows, with "?".
