### PR TITLE
Added correct Tensorflow library to fix ExtendedTests builds to succeed on Linux distros on Python 2.7

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -358,7 +358,9 @@ if "%InstallPythonPackages%" == "True" (
     )
 
     call "%PythonExe%" -m pip install --upgrade "%__currentScriptDir%target\%WheelFile%"
+    if %PythonVersion% == 3.6 ( call "%PythonExe%" -m pip install --upgrade pip )
     if %PythonVersion% == 3.5 ( call "%PythonExe%" -m pip install --upgrade pip )
+    if %PythonVersion% == 2.7 ( call "%PythonExe%" -m pip install --upgrade pip )
     call "%PythonExe%" -m pip install "scikit-learn==0.19.2"
 )
 

--- a/build.cmd
+++ b/build.cmd
@@ -358,7 +358,6 @@ if "%InstallPythonPackages%" == "True" (
     )
 
     call "%PythonExe%" -m pip install --upgrade "%__currentScriptDir%target\%WheelFile%"
-    if %PythonVersion% == 3.5 ( call "%PythonExe%" -m pip install --upgrade pip )
     call "%PythonExe%" -m pip install "scikit-learn==0.19.2"
 )
 

--- a/build.cmd
+++ b/build.cmd
@@ -358,6 +358,7 @@ if "%InstallPythonPackages%" == "True" (
     )
 
     call "%PythonExe%" -m pip install --upgrade "%__currentScriptDir%target\%WheelFile%"
+    if %PythonVersion% == 3.5 ( call "%PythonExe%" -m pip install --upgrade pip )
     call "%PythonExe%" -m pip install "scikit-learn==0.19.2"
 )
 

--- a/build.cmd
+++ b/build.cmd
@@ -358,9 +358,7 @@ if "%InstallPythonPackages%" == "True" (
     )
 
     call "%PythonExe%" -m pip install --upgrade "%__currentScriptDir%target\%WheelFile%"
-    if %PythonVersion% == 3.6 ( call "%PythonExe%" -m pip install --upgrade pip )
     if %PythonVersion% == 3.5 ( call "%PythonExe%" -m pip install --upgrade pip )
-    if %PythonVersion% == 2.7 ( call "%PythonExe%" -m pip install --upgrade pip )
     call "%PythonExe%" -m pip install "scikit-learn==0.19.2"
 )
 

--- a/build.sh
+++ b/build.sh
@@ -219,6 +219,11 @@ then
             ext=*.dylib
 		fi	
 		cp  "${BuildOutputDir}/${__configuration}/Platform/${PublishDir}"/publish/${ext} "${__currentScriptDir}/src/python/nimbusml/internal/libs/"
+		# Obtain "libtensorflow_framework.so.1", which is the upgraded version of "libtensorflow.so". This is required for tests TensorFlowScorer.py to pass in Linux distros with Python 2.7
+		if [ ! "$(uname -s)" = "Darwin" ]
+		then
+			cp  "${BuildOutputDir}/${__configuration}/Platform/${PublishDir}"/publish/libtensorflow_framework.so.1 "${__currentScriptDir}/src/python/nimbusml/internal/libs/"
+        fi
 		# remove dataprep dlls as its not supported in python 2.7
 		rm -f "${__currentScriptDir}/src/python/nimbusml/internal/libs/Microsoft.DPrep.*"
 		rm -f "${__currentScriptDir}/src/python/nimbusml/internal/libs/Microsoft.Data.*"

--- a/build.sh
+++ b/build.sh
@@ -219,6 +219,8 @@ then
             ext=*.dylib
 		fi	
 		cp  "${BuildOutputDir}/${__configuration}/Platform/${PublishDir}"/publish/${ext} "${__currentScriptDir}/src/python/nimbusml/internal/libs/"
+        # Obtain "libtensorflow_framework.so.1", which is the upgraded version of "libtensorflow.so". This is required for tests TensorFlowScorer.py to pass in Linux distros with Python 2.7
+        cp  "${BuildOutputDir}/${__configuration}/Platform/${PublishDir}"/publish/libtensorflow_framework.so.1 "${__currentScriptDir}/src/python/nimbusml/internal/libs/"
 		# remove dataprep dlls as its not supported in python 2.7
 		rm -f "${__currentScriptDir}/src/python/nimbusml/internal/libs/Microsoft.DPrep.*"
 		rm -f "${__currentScriptDir}/src/python/nimbusml/internal/libs/Microsoft.Data.*"

--- a/build.sh
+++ b/build.sh
@@ -219,8 +219,6 @@ then
             ext=*.dylib
 		fi	
 		cp  "${BuildOutputDir}/${__configuration}/Platform/${PublishDir}"/publish/${ext} "${__currentScriptDir}/src/python/nimbusml/internal/libs/"
-        # Obtain "libtensorflow_framework.so.1", which is the upgraded version of "libtensorflow.so". This is required for tests TensorFlowScorer.py to pass in Linux distros with Python 2.7
-        cp  "${BuildOutputDir}/${__configuration}/Platform/${PublishDir}"/publish/libtensorflow_framework.so.1 "${__currentScriptDir}/src/python/nimbusml/internal/libs/"
 		# remove dataprep dlls as its not supported in python 2.7
 		rm -f "${__currentScriptDir}/src/python/nimbusml/internal/libs/Microsoft.DPrep.*"
 		rm -f "${__currentScriptDir}/src/python/nimbusml/internal/libs/Microsoft.Data.*"

--- a/build.sh
+++ b/build.sh
@@ -206,7 +206,7 @@ then
     cp  "${BuildOutputDir}/${__configuration}"/DotNetBridge.dll "${__currentScriptDir}/src/python/nimbusml/internal/libs/"
     cp  "${BuildOutputDir}/${__configuration}"/pybridge.so "${__currentScriptDir}/src/python/nimbusml/internal/libs/"
 
-	# ls "${BuildOutputDir}/${__configuration}/Platform/${PublishDir}"/publish/
+	ls "${BuildOutputDir}/${__configuration}/Platform/${PublishDir}"/publish/
     if [ ${PythonVersion} = 2.7 ]
     then
         cp  "${BuildOutputDir}/${__configuration}/Platform/${PublishDir}"/publish/*.dll "${__currentScriptDir}/src/python/nimbusml/internal/libs/"


### PR DESCRIPTION
Fixes #299 

Added libtensorflow_framework.so.1 in addition to libtensorflow.so for builds with Python 2.7 on Ubuntu 16, Ubuntu14, and CentOS7. This fixes tests in TensorFlowScorer.py to assert correctly.