### PR TITLE
Added correct Tensorflow library to fix ExtendedTests builds to succeed on Linux distros on Python 2.7

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -219,6 +219,11 @@ then
             ext=*.dylib
 		fi	
 		cp  "${BuildOutputDir}/${__configuration}/Platform/${PublishDir}"/publish/${ext} "${__currentScriptDir}/src/python/nimbusml/internal/libs/"
+		# Obtain "libtensorflow_framework.so.1", which is the upgraded version of "libtensorflow.so". This is required for tests TensorFlowScorer.py to pass in Linux distros with Python 2.7
+		if [ ! "$(uname -s)" = "Darwin" ]
+		then
+			cp  "${BuildOutputDir}/${__configuration}/Platform/${PublishDir}"/publish/libtensorflow_framework.so.1 "${__currentScriptDir}/src/python/nimbusml/internal/libs/"
+		fi
 		# remove dataprep dlls as its not supported in python 2.7
 		rm -f "${__currentScriptDir}/src/python/nimbusml/internal/libs/Microsoft.DPrep.*"
 		rm -f "${__currentScriptDir}/src/python/nimbusml/internal/libs/Microsoft.Data.*"


### PR DESCRIPTION
Added libtensorflow_framework.so.1 in addition to libtensorflow.so for builds with Python 2.7 on Ubuntu 16, Ubuntu14, and CentOS7. This fixes tests in TensorFlowScorer.py to assert correctly.

Fixes #299 