### PR TITLE
Turn off shuffling for FactorizationMachineBinaryClassifier.

### DIFF
--- a/src/python/tests/test_estimator_checks.py
+++ b/src/python/tests/test_estimator_checks.py
@@ -8,6 +8,7 @@ run check_estimator tests
 import json
 import os
 
+from nimbusml.decomposition import FactorizationMachineBinaryClassifier
 from nimbusml.ensemble import EnsembleClassifier
 from nimbusml.ensemble import EnsembleRegressor
 from nimbusml.ensemble import LightGbmBinaryClassifier
@@ -193,6 +194,7 @@ NOBINARY_CHECKS = [
 INSTANCES = {
     'EnsembleClassifier': EnsembleClassifier(num_models=3),
     'EnsembleRegressor': EnsembleRegressor(num_models=3),
+    'FactorizationMachineBinaryClassifier': FactorizationMachineBinaryClassifier(shuffle=False),
     'LightGbmBinaryClassifier': LightGbmBinaryClassifier(
         minimum_example_count_per_group=1, minimum_example_count_per_leaf=1),
     'LightGbmClassifier': LightGbmClassifier(


### PR DESCRIPTION
Attempt to fix  the intermittent test_estimator_checks failures with `FactorizationMachineBinaryClassifier`.