### PR TITLE
Added utf-8 encoding to NGramExtractor.py

### DIFF
--- a/src/python/nimbusml/examples/NGramExtractor.py
+++ b/src/python/nimbusml/examples/NGramExtractor.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ###############################################################################
 # NGramExtractor
 from nimbusml import FileDataStream, Pipeline


### PR DESCRIPTION
Fixes #327 

NGramExtractor.py, in addition to NGramExtractor_df.py and Schema.py, also needs the encoding `# -*- coding: utf-8 -*-` added, as NGramExtractor.py also contains `␂`. This is resulting in Python 2.7 builds to fail still.
