### PR TITLE
Fix DbgWinPy2.7 build which was failing when building NativeBridge.

### DIFF
--- a/src/NativeBridge/NativeBridge.vcxproj
+++ b/src/NativeBridge/NativeBridge.vcxproj
@@ -150,7 +150,7 @@
       <PreprocessorDefinitions>CORECLR;_DEBUG;_WINDOWS;_USRDLL;PYBRIDGE_EXPORTS;BOOST_USE_STATIC_LIBS;BOOST_PYTHON_STATIC_LIB;BOOST_ALL_NO_LIB;BOOST_NUMPY_STATIC_LIB;_HAS_ITERATOR_DEBUGGING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(BoostRoot)\Include;$(PythonRoot)\include</AdditionalIncludeDirectories>
       <MinimalRebuild>true</MinimalRebuild>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
     </ClCompile>
     <Link>

--- a/src/NativeBridge/NativeBridge.vcxproj
+++ b/src/NativeBridge/NativeBridge.vcxproj
@@ -150,7 +150,7 @@
       <PreprocessorDefinitions>CORECLR;_DEBUG;_WINDOWS;_USRDLL;PYBRIDGE_EXPORTS;BOOST_USE_STATIC_LIBS;BOOST_PYTHON_STATIC_LIB;BOOST_ALL_NO_LIB;BOOST_NUMPY_STATIC_LIB;_HAS_ITERATOR_DEBUGGING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(BoostRoot)\Include;$(PythonRoot)\include</AdditionalIncludeDirectories>
       <MinimalRebuild>true</MinimalRebuild>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary> 
       <FunctionLevelLinking>true</FunctionLevelLinking>
     </ClCompile>
     <Link>


### PR DESCRIPTION
Here is one of the error messages:

```console
libboost_numpy-vc140-mt-gd-1_64.lib(ndarray.obj) : error LNK2038:
mismatch detected for 'RuntimeLibrary': value 'MDd_DynamicDebug'
doesn't match value 'MTd_StaticDebug' in DataViewInterop.obj
```

This was making it difficult to verify changes on Python 2.7.
