### PR TITLE
Decrease the size of the images in the Image and Image_df examples.

### DIFF
--- a/src/python/nimbusml/examples/Image.py
+++ b/src/python/nimbusml/examples/Image.py
@@ -18,7 +18,7 @@ data = pandas.DataFrame(data=dict(
 X = data[['Path']]
 y = data[['Label']]
 
-# define the training pipeline
+# define the training pipeline 
 pipeline = Pipeline([
     Loader(columns={'ImgPath': 'Path'}),
     Resizer(image_width=32, image_height=32,

--- a/src/python/nimbusml/examples/Image.py
+++ b/src/python/nimbusml/examples/Image.py
@@ -21,7 +21,7 @@ y = data[['Label']]
 # define the training pipeline
 pipeline = Pipeline([
     Loader(columns={'ImgPath': 'Path'}),
-    Resizer(image_width=227, image_height=227,
+    Resizer(image_width=32, image_height=32,
             columns={'ImgResize': 'ImgPath'}),
     PixelExtractor(columns={'ImgPixels': 'ImgResize'}),
     FastLinearBinaryClassifier(feature='ImgPixels')

--- a/src/python/nimbusml/examples/examples_from_dataframe/Image_df.py
+++ b/src/python/nimbusml/examples/examples_from_dataframe/Image_df.py
@@ -18,7 +18,7 @@ y = data[['Label']]
 
 # transforms and learners
 transform_1 = Loader() << 'Path'
-transform_2 = Resizer(image_width=227, image_height=227)
+transform_2 = Resizer(image_width=32, image_height=32)
 transform_3 = PixelExtractor()
 algo = FastLinearBinaryClassifier() << 'Path'
 


### PR DESCRIPTION
This speeds up each image example from 10mins to 8 seconds (locally).