### PR TITLE
Add Google.Protobuf.dll to Mac and Linux builds

### DIFF
--- a/build/libs_linux.txt
+++ b/build/libs_linux.txt
@@ -1,3 +1,4 @@
+Google.Protobuf.dll
 Newtonsoft.Json.dll
 libCpuMathNative.so
 libFastTreeNative.so

--- a/build/libs_mac.txt
+++ b/build/libs_mac.txt
@@ -1,3 +1,4 @@
+Google.Protobuf.dll
 Newtonsoft.Json.dll
 libCpuMathNative.dylib
 libFastTreeNative.dylib


### PR DESCRIPTION
Added Google.Protobuf.dll to Mac and Linux builds, which allows TensorFlowScorer to run properly in examples/TensorFlowScorer.py .
Fixes Issue #357 .