### PR TITLE
Set size variable to -1 in GetUnicodeTX to fix Python 2.7 encoding/decoding issue

### DIFF
--- a/src/NativeBridge/DataViewInterop.h
+++ b/src/NativeBridge/DataViewInterop.h
@@ -240,7 +240,7 @@ private:
 
         if (bp::extract<const char*>(str(s).encode("utf_8")).check())
         {
-			 size = -1;
+			size = -1;
             missing = -1;
             pch = bp::extract<const char*>(str(s).encode("utf_8"));
 #if _MSC_VER

--- a/src/NativeBridge/DataViewInterop.h
+++ b/src/NativeBridge/DataViewInterop.h
@@ -240,7 +240,7 @@ private:
 
         if (bp::extract<const char*>(str(s).encode("utf_8")).check())
         {
-			size = -1;
+            size = -1;
             missing = -1;
             pch = bp::extract<const char*>(str(s).encode("utf_8"));
 #if _MSC_VER

--- a/src/NativeBridge/DataViewInterop.h
+++ b/src/NativeBridge/DataViewInterop.h
@@ -240,6 +240,7 @@ private:
 
         if (bp::extract<const char*>(str(s).encode("utf_8")).check())
         {
+			 size = -1;
             missing = -1;
             pch = bp::extract<const char*>(str(s).encode("utf_8"));
 #if _MSC_VER

--- a/src/python/nimbusml/tests/ensemble/test_lightgbmclassifier.py
+++ b/src/python/nimbusml/tests/ensemble/test_lightgbmclassifier.py
@@ -19,8 +19,6 @@ from sklearn.utils.testing import assert_greater
 
 class TestLightGbmClassifier(unittest.TestCase):
 
-    @unittest.skipIf(platform.system() in ("Linux", "Darwin") and six.PY2,
-                     "encoding/decoding issues with linux py2.7, bug 286536")
     def test_lightgbmclassifier(self):
         np.random.seed(0)
         train_file = get_dataset('wiki_detox_train').as_filepath()

--- a/src/python/nimbusml/tests/feature_extraction/text/test_ngramfeaturizer.py
+++ b/src/python/nimbusml/tests/feature_extraction/text/test_ngramfeaturizer.py
@@ -18,8 +18,6 @@ from sklearn.utils.testing import assert_equal
 
 class TestNGramFeaturizer(unittest.TestCase):
 
-    @unittest.skipIf(os.name != "nt" and six.PY2,
-                     "encoding/decoding issues with linux py2.7, bug 286536")
     def test_ngramfeaturizer(self):
         np.random.seed(0)
         train_file = get_dataset('wiki_detox_train').as_filepath()

--- a/src/python/nimbusml/tests/feature_extraction/text/test_ngramfeaturizer.py
+++ b/src/python/nimbusml/tests/feature_extraction/text/test_ngramfeaturizer.py
@@ -34,7 +34,7 @@ class TestNGramFeaturizer(unittest.TestCase):
             word_feature_extractor=n_gram(),
             vector_normalizer='None') << 'SentimentText'
         X_train = texttransform.fit_transform(X_train[:100])
-        sum = X_train.iloc[:].sum().sum()
+        sum = X_train.iloc[:].sum()
         print(sum)
         assert_equal(sum, 30513, "sum of all features is incorrect!")
 

--- a/src/python/nimbusml/tests/feature_extraction/text/test_ngramfeaturizer.py
+++ b/src/python/nimbusml/tests/feature_extraction/text/test_ngramfeaturizer.py
@@ -34,7 +34,7 @@ class TestNGramFeaturizer(unittest.TestCase):
             word_feature_extractor=n_gram(),
             vector_normalizer='None') << 'SentimentText'
         X_train = texttransform.fit_transform(X_train[:100])
-        sum = X_train.iloc[:].sum()
+        sum = X_train.iloc[:].sum().sum()
         print(sum)
         assert_equal(sum, 30513, "sum of all features is incorrect!")
 

--- a/src/python/nimbusml/tests/naive_bayes/test_naivebayesclassifier.py
+++ b/src/python/nimbusml/tests/naive_bayes/test_naivebayesclassifier.py
@@ -19,8 +19,6 @@ from sklearn.utils.testing import assert_greater
 
 class TestNaiveBayesClassifier(unittest.TestCase):
 
-    @unittest.skipIf(os.name != "nt" and six.PY2,
-                     "encoding/decoding issues with linux py2.7, bug 286536")
     def test_naivebayesclassifier(self):
         np.random.seed(0)
         train_file = get_dataset("wiki_detox_train").as_filepath()


### PR DESCRIPTION
Fixes #351 

Set size variable to -1 in GetUnicodeTX. In the function that ran on all versions of Python except 3.6 on UNIX systems, this size value responsible for telling the C# end the size of the string was being set to -1. This size variable wasn't being set to anything in the managed callback function for Python 2.7. Setting it to -1 worked, as this way, the c# side understood to do a necessary utf8-utf16 conversion, which produced the correct size amount.

This also allows for test cases that are skipped on Python 2.7 due to "encoding/decoding" bug to be ran properly.