### PR TITLE
Supporting pathlib's Path objects in FileDataStream

### DIFF
--- a/src/python/nimbusml/internal/utils/data_stream.py
+++ b/src/python/nimbusml/internal/utils/data_stream.py
@@ -8,6 +8,7 @@ Owns nimbusml's containers.
 import os
 import tempfile
 from shutil import copyfile
+from pathlib import Path
 
 from .data_roles import DataRoles
 from .data_schema import DataSchema
@@ -229,6 +230,10 @@ class FileDataStream(DataStream):
         :param schema: filename schema
         """
         super(FileDataStream, self).__init__(schema, roles)
+
+        if isinstance(filename, Path):
+            filename = str(filename.resolve())
+
         self._filename = filename
 
     def __repr__(self):

--- a/src/python/nimbusml/tests/test_data_stream.py
+++ b/src/python/nimbusml/tests/test_data_stream.py
@@ -10,6 +10,7 @@ import numpy
 import pandas
 from nimbusml import DataSchema
 from nimbusml import FileDataStream
+from pathlib import Path
 
 try:
     from pandas.testing import assert_frame_equal
@@ -29,6 +30,17 @@ class TestDataStream(unittest.TestCase):
         fi2 = fi.clone()
         assert repr(fi) == repr(fi2)
         os.remove(f.name)
+
+    def test_data_stream_path_object(self):
+        df = pandas.DataFrame(dict(a=[0, 1], b=[0.1, 0.2]))
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            df.to_csv(f, sep=',', index=False)
+        
+        fi = FileDataStream.read_csv(Path(f.name), sep=',')
+        fi2 = fi.clone()
+        assert repr(fi) == repr(fi2)
+        os.remove(f.name)
+
 
     def test_data_header_no_dataframe(self):
         li = [1.0, 1.0, 2.0]


### PR DESCRIPTION
Fixes #269 .  `pathlib`'s Path objects can be converted to strings just by casting, and vice versa.  I added a check in `FileDataStream`'s init function to convert a Path object to a string.  I also wrote a test for this, but calling `FileDataStream.read_csv()` on a Path object produces the following error (using tool=None/'pandas'):

<img width="836" alt="Screen Shot 2019-11-28 at 7 34 09 PM" src="https://user-images.githubusercontent.com/46606987/69843881-6aa63480-1237-11ea-8657-dc0b9451871a.png">

@ganik  do I need to define my own schema for a file path as a Path object, even though the contents of the file should be the same?  I'm a little stuck here and any help would be appreciated!
