### PR TITLE
Disabled tests that only fail on Mac Py2.7 due to string encoding/dec…

### DIFF
--- a/src/python/nimbusml/tests/ensemble/test_lightgbmclassifier.py
+++ b/src/python/nimbusml/tests/ensemble/test_lightgbmclassifier.py
@@ -19,6 +19,10 @@ from sklearn.utils.testing import assert_greater
 
 class TestLightGbmClassifier(unittest.TestCase):
 
+    @unittest.skipIf(platform.system() == "Darwin" and six.PY2,
+    "Disabled due to bug on Mac Python 2.7 build, more info: \
+    https://github.com/microsoft/NimbusML/issues/366, \
+    https://github.com/microsoft/NimbusML/pull/362")
     def test_lightgbmclassifier(self):
         np.random.seed(0)
         train_file = get_dataset('wiki_detox_train').as_filepath()

--- a/src/python/nimbusml/tests/feature_extraction/text/test_ngramfeaturizer.py
+++ b/src/python/nimbusml/tests/feature_extraction/text/test_ngramfeaturizer.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------------------------
 
-import os
+import platform
 import unittest
 
 import numpy as np

--- a/src/python/nimbusml/tests/feature_extraction/text/test_ngramfeaturizer.py
+++ b/src/python/nimbusml/tests/feature_extraction/text/test_ngramfeaturizer.py
@@ -18,6 +18,10 @@ from sklearn.utils.testing import assert_equal
 
 class TestNGramFeaturizer(unittest.TestCase):
 
+    @unittest.skipIf(platform.system() == "Darwin" and six.PY2,
+    "Disabled due to bug on Mac Python 2.7 build, more info: \
+    https://github.com/microsoft/NimbusML/issues/366, \
+    https://github.com/microsoft/NimbusML/pull/362")
     def test_ngramfeaturizer(self):
         np.random.seed(0)
         train_file = get_dataset('wiki_detox_train').as_filepath()


### PR DESCRIPTION
Disabled tests that only fail on Mac Python 2.7 due to the string encoding/decoding bug noted on Issue #366 .