### PR TITLE
Add docs for the as_csr output format parameter.

### DIFF
--- a/src/python/nimbusml/base_transform.py
+++ b/src/python/nimbusml/base_transform.py
@@ -35,7 +35,19 @@ class BaseTransform(BaseEstimator, BasePipelineItem):
         :param X: array-like with shape=[n_samples, n_features] or else
         :py:class:`nimbusml.FileDataStream`
         :param y: array-like with shape=[n_samples]
-        :return: pandas.DataFrame
+        :param as_binary_data_stream: If ``True`` then output an IDV file.
+            See `here <https://github.com/dotnet/machinelearning/blob/master/docs/code/IDataViewImplementation.md>`_
+            for more information.
+        :param params: Additional arguments.
+            If ``as_csr=True`` and ``as_binary_data_stream=False`` then
+            return the transformed data in CSR (sparse matrix) format.
+            If ``as_binary_data_stream`` is also true then that
+            parameter takes precedence over ``as_csr`` and the output will
+            be an IDV file.
+
+        :return: Returns a pandas DataFrame if no other output format
+            is specified. See ``as_binary_data_stream`` and ``as_csr``
+            for other available output formats.
         """
         pipeline = Pipeline([self])
         try:
@@ -88,8 +100,20 @@ class BaseTransform(BaseEstimator, BasePipelineItem):
         Applies transform to data.
 
         :param X: array-like with shape=[n_samples, n_features] or else
-        :py:class:`nimbusml.FileDataStream`
-        :return: pandas.DataFrame
+            :py:class:`nimbusml.FileDataStream`
+        :param as_binary_data_stream: If ``True`` then output an IDV file.
+            See `here <https://github.com/dotnet/machinelearning/blob/master/docs/code/IDataViewImplementation.md>`_
+            for more information.
+        :param params: Additional arguments.
+            If ``as_csr=True`` and ``as_binary_data_stream=False`` then
+            return the transformed data in CSR (sparse matrix) format.
+            If ``as_binary_data_stream`` is also true then that
+            parameter takes precedence over ``as_csr`` and the output will
+            be an IDV file.
+
+        :return: Returns a pandas DataFrame if no other output format
+            is specified. See ``as_binary_data_stream`` and ``as_csr``
+            for other available output formats.
         """
         # Check that the input is of the same shape as the one passed
         # during

--- a/src/python/nimbusml/pipeline.py
+++ b/src/python/nimbusml/pipeline.py
@@ -1223,6 +1223,19 @@ class Pipeline:
         :param X: {array-like [n_samples, n_features],
             :py:func:`FileDataStream <nimbusml.FileDataStream>` }
         :param y: {array-like [n_samples]}
+        :param as_binary_data_stream: If ``True`` then output an IDV file.
+            See `here <https://github.com/dotnet/machinelearning/blob/master/docs/code/IDataViewImplementation.md>`_
+            for more information.
+        :param params: Additional arguments.
+            If ``as_csr=True`` and ``as_binary_data_stream=False`` then
+            return the transformed data in CSR (sparse matrix) format.
+            If ``as_binary_data_stream`` is also true then that
+            parameter takes precedence over ``as_csr`` and the output will
+            be an IDV file.
+
+        :return: Returns a pandas DataFrame if no other output format
+            is specified. See ``as_binary_data_stream`` and ``as_csr``
+            for other available output formats.
         """
         self.fit(
             X,
@@ -2447,7 +2460,19 @@ class Pipeline:
         :param X: {array-like [n_samples, n_features],
             :py:class:`nimbusml.FileDataStream` }
         :param y: {array-like [n_samples]}
+        :param as_binary_data_stream: If ``True`` then output an IDV file.
+            See `here <https://github.com/dotnet/machinelearning/blob/master/docs/code/IDataViewImplementation.md>`_
+            for more information.
+        :param params: Additional arguments.
+            If ``as_csr=True`` and ``as_binary_data_stream=False`` then
+            return the transformed data in CSR (sparse matrix) format.
+            If ``as_binary_data_stream`` is also true then that
+            parameter takes precedence over ``as_csr`` and the output will
+            be an IDV file.
 
+        :return: Returns a pandas DataFrame if no other output format
+            is specified. See ``as_binary_data_stream`` and ``as_csr``
+            for other available output formats.
         """
         # start the clock!
         start_time = time.time()


### PR DESCRIPTION
Still need to update the __Output Data Types of Transforms__ section of `src\python\docs\sphinx\concepts\datasources.rst`. The sphinx documentation creation tools need to be fixed before this can happen so for the meantime I will update the docs directly in the doc repo.