### PR TITLE
Re-run failed unit tests on Ubuntu/Mac

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -307,7 +307,8 @@ then
     TestsPath2=${__currentScriptDir}/src/python/tests
     TestsPath3=${__currentScriptDir}/src/python/tests_extended
     ReportPath=${__currentScriptDir}/build/TestCoverageReport
-    "${PythonExe}" -m pytest -n 4 --verbose --maxfail=1000 --capture=sys "${TestsPath2}" "${TestsPath1}"
+    "${PythonExe}" -m pytest -n 4 --verbose --maxfail=1000 --capture=sys "${TestsPath2}" "${TestsPath1}" || \
+        "${PythonExe}" -m pytest -n 4 --last-failed --verbose --maxfail=1000 --capture=sys "${TestsPath2}" "${TestsPath1}"
 
     if [ ${__runExtendedTests} = true ]
     then

--- a/build.sh
+++ b/build.sh
@@ -308,7 +308,7 @@ then
     TestsPath3=${__currentScriptDir}/src/python/tests_extended
     ReportPath=${__currentScriptDir}/build/TestCoverageReport
     "${PythonExe}" -m pytest -n 4 --verbose --maxfail=1000 --capture=sys "${TestsPath2}" "${TestsPath1}" || \
-        "${PythonExe}" -m pytest -n 4 --last-failed --verbose --maxfail=1000 --capture=sys "${TestsPath2}" "${TestsPath1}"
+        "${PythonExe}" -m pytest -n 4 --last-failed --verbose --maxfail=1000 --capture=sys "${TestsPath2}" "${TestsPath1}" 
 
     if [ ${__runExtendedTests} = true ]
     then

--- a/src/python/nimbusml/tests/test_csr_matrix_output.py
+++ b/src/python/nimbusml/tests/test_csr_matrix_output.py
@@ -35,6 +35,8 @@ class TestCsrMatrixOutput(unittest.TestCase):
 
         self.assertTrue(result.equals(expected_result))
 
+        self.fail('Forced failure to test pytest restart.')
+
     def test_fit_transform_produces_expected_result(self):
         train_data = {'c1': [1, 0, 0, 4],
                       'c2': [2, 3, 0, 5],

--- a/src/python/nimbusml/tests/test_csr_matrix_output.py
+++ b/src/python/nimbusml/tests/test_csr_matrix_output.py
@@ -35,8 +35,6 @@ class TestCsrMatrixOutput(unittest.TestCase):
 
         self.assertTrue(result.equals(expected_result))
 
-        self.fail('Forced failure to test pytest restart.')
-
     def test_fit_transform_produces_expected_result(self):
         train_data = {'c1': [1, 0, 0, 4],
                       'c2': [2, 3, 0, 5],

--- a/src/python/nimbusml/tests/test_csr_matrix_output.py
+++ b/src/python/nimbusml/tests/test_csr_matrix_output.py
@@ -35,15 +35,6 @@ class TestCsrMatrixOutput(unittest.TestCase):
 
         self.assertTrue(result.equals(expected_result))
 
-        import os
-        filename = 'csr_test_executed'
-        if not os.path.exists(filename):
-            with open(filename, 'a'):
-                os.utime(filename, None)
-
-            self.fail('Forced failure to test restart functionality on Mac/Linux')
-
-
     def test_fit_transform_produces_expected_result(self):
         train_data = {'c1': [1, 0, 0, 4],
                       'c2': [2, 3, 0, 5],

--- a/src/python/nimbusml/tests/test_csr_matrix_output.py
+++ b/src/python/nimbusml/tests/test_csr_matrix_output.py
@@ -35,6 +35,15 @@ class TestCsrMatrixOutput(unittest.TestCase):
 
         self.assertTrue(result.equals(expected_result))
 
+        import os
+        filename = 'csr_test_executed'
+        if not os.path.exists(filename):
+            with open(filename, 'a'):
+                os.utime(filename, None)
+
+            self.fail('Forced failure to test restart functionality on Mac/Linux')
+
+
     def test_fit_transform_produces_expected_result(self):
         train_data = {'c1': [1, 0, 0, 4],
                       'c2': [2, 3, 0, 5],


### PR DESCRIPTION
Re-run any failed unit tests on Ubuntu/Mac to help deal with intermittent crashes. This matches the behavior of the Windows build environment.

Note, this modification only handles intermittent crashes on Ubuntu/Mac unit test runs. It does not handle situations where the build hangs and never returns control to the build script.