### PR TITLE
Fix issue when specifying split_start='after_transforms' with CV.fit()

### DIFF
--- a/src/python/nimbusml/internal/utils/entrypoints.py
+++ b/src/python/nimbusml/internal/utils/entrypoints.py
@@ -320,8 +320,8 @@ class Graph(EntryPoint):
         return pieces[0].replace("sep=", "").strip()
 
     def run(self, X, y=None, max_slots=-1, random_state=None, verbose=1, **params):
-        if params.get("dryrun") is not None:
-            return 'graph = %s' % (str(self))
+        if params.get("dry_run", False):
+            return str(self)
 
         output_modelfilename = None
         output_predictor_modelfilename = None

--- a/src/python/nimbusml/tests/test_entrypoints.py
+++ b/src/python/nimbusml/tests/test_entrypoints.py
@@ -118,8 +118,12 @@ class TestEntryPoints(unittest.TestCase):
                 input_data=""), dict(
                 output_model=""), DataOutputFormat.DF, *all_nodes)
         # print(graph)
-        graph.run(X=None, dryrun=True)
+        graph.run(X=None, dry_run=True)
 
         # lr = graph.run(formula = "ylogical ~ xint1", data = ds
         #    , blocks_per_read = 1, report_progress = True
         #    )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix issue when specifying split_start='after_transforms' with CV.fit() when the explicit transforms contain presteps.