### PR TITLE
Fix build issue caused by latest version of pip (>=20.0.0)

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -387,7 +387,7 @@ if "%InstallPythonPackages%" == "True" (
     echo "#################################"
     echo "Installing python packages ... "
     echo "#################################"
-    call "%PythonExe%" -m pip install --upgrade pip
+    call "%PythonExe%" -m pip install --upgrade "pip==19.3.1"
     call "%PythonExe%" -m pip install --upgrade nose pytest pytest-xdist graphviz imageio pytest-cov "jupyter_client>=4.4.0" "nbconvert>=4.2.0"
 
     if %PythonVersion% == 2.7 (


### PR DESCRIPTION
The latest version of `pip` which was released today is not able to install `dotnetcore2` on Windows. Force the use of the previous version until this issue has been resolved.

```console
ERROR: Could not find a version that satisfies the requirement dotnetcore2>=2.1.9 (from azureml-dataprep>=1.1.33) (from versions: none)
ERROR: No matching distribution found for dotnetcore2>=2.1.9 (from azureml-dataprep>=1.1.33)
ERROR: Could not find a version that satisfies the requirement dotnetcore2>=2.1.2 (from nimbusml==1.6.1) (from versions: none)
ERROR: No matching distribution found for dotnetcore2>=2.1.2 (from nimbusml==1.6.1)
```

The [release notes](https://pip.pypa.io/en/stable/news/) for `pip 20.0.0.` state that dependency handling and wheel tag calculation has changed. This might be what is causing the issue.