### PR TITLE
Change how data_frame_tool handles categorical columns

### DIFF
--- a/src/python/tests_extended/data_frame_tool.py
+++ b/src/python/tests_extended/data_frame_tool.py
@@ -111,6 +111,8 @@ class DataFrameTool():
                 self._validate_type(input_meta, df[input_meta.name].dtype)
                 if (df[input_meta.name].dtype) == 'datetime64[ns]':
                     input_array = np.array([dt.timestamp() for dt in df[input_meta.name]]).astype(np.int64)
+                elif (str(df[input_meta.name].dtype)) == 'category':
+                    input_array = np.array([dt + 1 for dt in df[input_meta.name]]).astype(np.uint32) # in ONNX models trained in ML.NET "categorical columns" are 1 based, not 0 based                    
                 else:
                     # With strings we must cast first to np.object then then reshape
                     # so we do it for everything


### PR DESCRIPTION
ONNX models trained in ML.NET (through NimbusML) expect keys which are 1 based. Pandas categorical columns are 0 based.To Use the ONNX models, it's needed to add 1 to the categorical columns.
